### PR TITLE
Release v0.5.0 - In Progress

### DIFF
--- a/org-transclusion-blocks-headers.el
+++ b/org-transclusion-blocks-headers.el
@@ -2,7 +2,7 @@
 
 ;; Author: Gino Cornejo
 ;; Maintainer: Gino Cornejo <gggion123@gmail.com>
-;; Homepage: https://github.com/gggion/org-transclusion-blocks
+;; URL: https://github.com/gggion/org-transclusion-blocks
 
 ;; This file is part of org-transclusion-blocks.
 

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -42,9 +42,6 @@
 (require 'org-transclusion-blocks-headers)
 (require 'transient)
 
-;;;; Compiler Declarations
-(defvar org-transclusion-blocks--undo-handle)
-
 ;;;; Customization
 
 (defgroup org-transclusion-blocks-lines nil
@@ -66,14 +63,21 @@ Used when no prefix argument provided to transient suffixes."
 
 Used to prevent downward scroll/expansion when already at bottom.
 
-Returns nil if no metadata available."
+Queries source buffer line count via headers.
+Returns nil if source cannot be determined."
   (let* ((current-range (org-transclusion-blocks-lines--get-current-range))
-         (current-end (cdr current-range))
-         (element (org-element-at-point))
-         (bounds (org-transclusion-blocks--get-content-bounds element))
-         (beg (car bounds))
-         (max-line (get-text-property beg 'org-transclusion-blocks-max-line)))
-    (and current-end max-line (>= current-end max-line))))
+         (current-end (cdr current-range)))
+    (when current-end
+      (let* ((element (org-element-at-point))
+             (type (org-element-type element))
+             (params (if (eq type 'src-block)
+                         (nth 2 (org-babel-get-src-block-info 'no-eval))
+                       (org-transclusion-blocks--parse-headers-direct element)))
+             (expanded-params (org-transclusion-blocks--expand-header-vars params))
+             (keyword-plist (org-transclusion-blocks--params-to-plist expanded-params))
+             (link-string (plist-get keyword-plist :link))
+             (max-line (org-transclusion-blocks--source-line-count link-string)))
+        (and max-line (>= current-end max-line))))))
 
 (defun org-transclusion-blocks-lines--at-lower-boundary-p ()
   "Return non-nil if range start is at line 1.
@@ -251,11 +255,7 @@ If range is 10-20, scrolling down by 3 produces 13-23.
 Prevented when end already at source maximum line."
   (interactive "p")
   (if (org-transclusion-blocks-lines--at-upper-boundary-p)
-      (let* ((element (org-element-at-point))
-             (bounds (org-transclusion-blocks--get-content-bounds element))
-             (beg (car bounds))
-             (max-line (get-text-property beg 'org-transclusion-blocks-max-line)))
-        (message "Cannot scroll beyond end of source (line %d)" max-line))
+      (message "Cannot scroll beyond end of source")
     (let* ((current (org-transclusion-blocks-lines--get-current-range))
            (start (car current))
            (end (cdr current)))
@@ -328,11 +328,7 @@ Example:
 Prevented when end already at source maximum line."
   (interactive "p")
   (if (org-transclusion-blocks-lines--at-upper-boundary-p)
-      (let* ((element (org-element-at-point))
-             (bounds (org-transclusion-blocks--get-content-bounds element))
-             (beg (car bounds))
-             (max-line (get-text-property beg 'org-transclusion-blocks-max-line)))
-        (message "Cannot expand beyond end of source (line %d)" max-line))
+      (message "Cannot expand beyond end of source")
     (let* ((current (org-transclusion-blocks-lines--get-current-range))
            (start (car current))
            (end (cdr current)))
@@ -395,26 +391,12 @@ Errors if end would go below start."
 (defun org-transclusion-blocks--lines-menu-cleanup ()
   "Cleanup function for lines menu transient exit.
 
-Consolidates undo history, applies overlays, and removes itself
-from hook.
+Removes itself from hook.
 
-Called after transient exits to finalize all changes made during
-interactive adjustment as a single undo unit."
-  (unwind-protect
-      (progn
-        ;; Consolidate undo history if handle exists
-        (when org-transclusion-blocks--undo-handle
-          (accept-change-group org-transclusion-blocks--undo-handle)
-          (undo-amalgamate-change-group org-transclusion-blocks--undo-handle)
-          (setq org-transclusion-blocks--undo-handle nil))
-
-        ;; Apply overlays
-        (org-transclusion-blocks--ensure-overlays-applied))
-
-    ;; Always remove hook
-    (remove-hook 'transient-exit-hook
-                 #'org-transclusion-blocks--lines-menu-cleanup
-                 t)))
+Called after transient exits."
+  (remove-hook 'transient-exit-hook
+               #'org-transclusion-blocks--lines-menu-cleanup
+               t))
 
 ;;;; Transient Menu
 
@@ -423,33 +405,12 @@ interactive adjustment as a single undo unit."
   "Adjust line range for transclusion at point.
 
 All commands accept prefix argument for custom increment.
-Default increment is `org-transclusion-blocks-lines-default-increment'.
-
-Suppresses overlay creation during adjustment via
-`org-transclusion-blocks--suppress-overlays' to improve
-performance.  Overlays are created once on menu exit.
-
-All changes made during menu interaction are amalgamated into
-a single undo step using the change group protocol."
+Default increment is `org-transclusion-blocks-lines-default-increment'."
   (interactive)
-
-  ;; Prepare change group for undo consolidation
-  (let ((handle (prepare-change-group)))
-    (setq org-transclusion-blocks--undo-handle handle)
-
-    ;; Activate the change group
-    (activate-change-group handle)
-
-    ;; Set suppression flag before entering transient
-    (setq org-transclusion-blocks--suppress-overlays t)
-
-    ;; Add exit hook for this buffer only
-    (add-hook 'transient-exit-hook
-              #'org-transclusion-blocks--lines-menu-cleanup
-              nil t)
-
-    ;; Enter the transient menu
-    (transient-setup 'org-transclusion-blocks-lines-menu-impl)))
+  (add-hook 'transient-exit-hook
+            #'org-transclusion-blocks--lines-menu-cleanup
+            nil t)
+  (transient-setup 'org-transclusion-blocks-lines-menu-impl))
 
 (transient-define-prefix org-transclusion-blocks-lines-menu-impl ()
   "Implementation of line range adjustment menu.

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -58,7 +58,7 @@ Used when no prefix argument provided to transient suffixes."
 
 ;;;; Internal Variables
 
-(defvar org-transclusion-blocks--inhibit-buffer-cleanup nil)
+(defvar org-transclusion-blocks--inhibit-buffer-cleanup)
 
 ;;;; Range Validation
 

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -2,7 +2,7 @@
 
 ;; Author: Gino Cornejo
 ;; Maintainer: Gino Cornejo <gggion123@gmail.com>
-;; Homepage: https://github.com/gggion/org-transclusion-blocks
+;; URL: https://github.com/gggion/org-transclusion-blocks
 
 ;; This file is part of org-transclusion-blocks.
 

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -42,6 +42,7 @@
 (require 'org-transclusion-blocks-headers)
 (require 'transient)
 
+(defvar org-transclusion-blocks--inhibit-buffer-cleanup)
 ;;;; Customization
 
 (defgroup org-transclusion-blocks-lines nil
@@ -58,7 +59,16 @@ Used when no prefix argument provided to transient suffixes."
 
 ;;;; Internal Variables
 
-(defvar org-transclusion-blocks--inhibit-buffer-cleanup)
+(defvar-local org-transclusion-blocks--undo-handle nil
+  "Change group handle for lines menu undo consolidation.
+
+Set by `org-transclusion-blocks-lines-menu' before entering transient.
+Consumed by `org-transclusion-blocks--lines-menu-cleanup' on exit.
+
+All header modifications and content re-fetches during interactive
+line range adjustment are amalgamated into a single undo step.
+
+Do not set globally.")
 
 ;;;; Range Validation
 
@@ -395,13 +405,21 @@ Errors if end would go below start."
 (defun org-transclusion-blocks--lines-menu-cleanup ()
   "Cleanup function for lines menu transient exit.
 
-Re-enable buffer cleanup and remove itself from hook.
+Consolidate undo history and re-enable buffer cleanup.
+
+All changes made during interactive adjustment are amalgamated
+into a single undo step via the change group protocol.
 
 Called after transient exits."
-  (setq org-transclusion-blocks--inhibit-buffer-cleanup nil)
-  (remove-hook 'transient-exit-hook
-               #'org-transclusion-blocks--lines-menu-cleanup
-               t))
+  (unwind-protect
+      (when org-transclusion-blocks--undo-handle
+        (accept-change-group org-transclusion-blocks--undo-handle)
+        (undo-amalgamate-change-group org-transclusion-blocks--undo-handle)
+        (setq org-transclusion-blocks--undo-handle nil))
+    (setq org-transclusion-blocks--inhibit-buffer-cleanup nil)
+    (remove-hook 'transient-exit-hook
+                 #'org-transclusion-blocks--lines-menu-cleanup
+                 t)))
 
 ;;;; Transient Menu
 
@@ -413,8 +431,14 @@ All commands accept prefix argument for custom increment.
 Default increment is `org-transclusion-blocks-lines-default-increment'.
 
 Inhibits buffer cleanup during transient to avoid opening and
-killing source buffers on each range adjustment."
+killing source buffers on each range adjustment.
+
+All changes made during menu interaction are amalgamated into
+a single undo step using the change group protocol."
   (interactive)
+  (let ((handle (prepare-change-group)))
+    (setq org-transclusion-blocks--undo-handle handle)
+    (activate-change-group handle))
   (setq org-transclusion-blocks--inhibit-buffer-cleanup nil)
   (add-hook 'transient-exit-hook
             #'org-transclusion-blocks--lines-menu-cleanup
@@ -459,3 +483,5 @@ Do not call directly; use `org-transclusion-blocks-lines-menu'."
     ("q" "Quit" transient-quit-one)]])
 
 (provide 'org-transclusion-blocks-lines)
+
+;;; org-transclusion-blocks-lines.el ends here

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -415,7 +415,7 @@ Default increment is `org-transclusion-blocks-lines-default-increment'.
 Inhibits buffer cleanup during transient to avoid opening and
 killing source buffers on each range adjustment."
   (interactive)
-  (setq org-transclusion-blocks--inhibit-buffer-cleanup t)
+  (setq org-transclusion-blocks--inhibit-buffer-cleanup nil)
   (add-hook 'transient-exit-hook
             #'org-transclusion-blocks--lines-menu-cleanup
             nil t)

--- a/org-transclusion-blocks-lines.el
+++ b/org-transclusion-blocks-lines.el
@@ -56,6 +56,10 @@ Used when no prefix argument provided to transient suffixes."
   :type 'integer
   :group 'org-transclusion-blocks-lines)
 
+;;;; Internal Variables
+
+(defvar org-transclusion-blocks--inhibit-buffer-cleanup nil)
+
 ;;;; Range Validation
 
 (defun org-transclusion-blocks-lines--at-upper-boundary-p ()
@@ -391,9 +395,10 @@ Errors if end would go below start."
 (defun org-transclusion-blocks--lines-menu-cleanup ()
   "Cleanup function for lines menu transient exit.
 
-Removes itself from hook.
+Re-enable buffer cleanup and remove itself from hook.
 
 Called after transient exits."
+  (setq org-transclusion-blocks--inhibit-buffer-cleanup nil)
   (remove-hook 'transient-exit-hook
                #'org-transclusion-blocks--lines-menu-cleanup
                t))
@@ -405,8 +410,12 @@ Called after transient exits."
   "Adjust line range for transclusion at point.
 
 All commands accept prefix argument for custom increment.
-Default increment is `org-transclusion-blocks-lines-default-increment'."
+Default increment is `org-transclusion-blocks-lines-default-increment'.
+
+Inhibits buffer cleanup during transient to avoid opening and
+killing source buffers on each range adjustment."
   (interactive)
+  (setq org-transclusion-blocks--inhibit-buffer-cleanup t)
   (add-hook 'transient-exit-hook
             #'org-transclusion-blocks--lines-menu-cleanup
             nil t)

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -123,10 +123,20 @@ RESOLVER receives link path string, returns absolute file path or nil.
 Check package availability inside RESOLVER via `fboundp'.
 
 Takes precedence over `org-transclusion-blocks-follow-types'.
-Populates `org-transclusion-blocks--link-handlers'."
+Populates `org-transclusion-blocks--link-handlers'.
+
+Installs `org-transclusion-blocks--add-by-link-handler' into
+`org-transclusion-add-functions' on first call.  Subsequent
+registrations reuse the existing hook entry."
   (setf (alist-get type org-transclusion-blocks--link-handlers
                    nil nil #'string=)
-        resolver))
+        resolver)
+  ;; Install handler on first registration
+  (unless (memq 'org-transclusion-blocks--add-by-link-handler
+                org-transclusion-add-functions)
+    (add-hook 'org-transclusion-add-functions
+              #'org-transclusion-blocks--add-by-link-handler
+              -5)))
 
 ;;;; Path Splitting
 
@@ -381,71 +391,23 @@ Called by `org-transclusion-blocks--add-by-follow',
 
 ;;;; id: Links with Search Options
 
-(defun org-transclusion-blocks--add-org-id-with-search (link plist)
-  "Handle id: LINK containing :: search option for PLIST.
-
-LINK is an `org-element' link object.
-PLIST is keyword plist passed unchanged to handlers.
-
-Return nil for id: links without :: to let upstream handle those.
-Return (:src-content nil) on UUID lookup failure to prevent
-fallthrough to upstream `org-transclusion-add-org-id'.
-
-Uses `org-transclusion-blocks--split-path-search' for :: splitting.
-Resolves UUID via `org-id-find'.
-Delegates to `org-transclusion-blocks--redispatch-as-file'.
-
-Installed at depth -10 in `org-transclusion-add-functions'."
-  (when (string= "id" (org-element-property :type link))
-    (pcase-let ((`(,id . ,search)
-                 (org-transclusion-blocks--split-path-search link)))
-      (when search
-        (let ((found (ignore-errors (org-id-find id))))
-          (if (not found)
-              (progn
-                (message
-                 "No transclusion done for ID %s at point %d, line %d"
-                 id (point) (org-current-line))
-                '(:src-content nil))
-            (org-transclusion-blocks--redispatch-as-file
-             (car found) search plist)))))))
-
 ;;;; Installation
 
 (defun org-transclusion-blocks--install-link-handlers ()
   "Install link handler functions into `org-transclusion-add-functions'.
 
-Prepend `org-transclusion-blocks--add-org-id-with-search' at depth -10
-before all other handlers to fix id: :: search option splitting.
-
-Install `org-transclusion-blocks--add-by-link-handler' at depth -5
-for explicit resolver registry.
-
 Install `org-transclusion-blocks--add-by-follow' at depth -4
 for unified follow-based resolution.
 
-Both resolver handlers must precede `org-transclusion-add-src-lines'
-\(depth 0), which does not check link type and would attempt to open
-non-file paths directly via `find-file-noselect' when :lines is in
-the plist.
+The explicit resolver handler (`org-transclusion-blocks--add-by-link-handler')
+is installed lazily by `org-transclusion-blocks-register-link-handler'
+on first resolver registration.
 
-Dedicated third-party handlers at depth 0 handle file: links
-produced by re-dispatch.  Idempotent; safe to call multiple times.
+Idempotent; safe to call multiple times.
 
 Called at load time by the top-level form at end of file."
-  ;; Remove old handler if present (renamed from generic-follow)
   (remove-hook 'org-transclusion-add-functions
                'org-transclusion-blocks--add-by-generic-follow)
-  (unless (memq 'org-transclusion-blocks--add-org-id-with-search
-                org-transclusion-add-functions)
-    (add-hook 'org-transclusion-add-functions
-              #'org-transclusion-blocks--add-org-id-with-search
-              -10))
-  (unless (memq 'org-transclusion-blocks--add-by-link-handler
-                org-transclusion-add-functions)
-    (add-hook 'org-transclusion-add-functions
-              #'org-transclusion-blocks--add-by-link-handler
-              -5))
   (unless (memq 'org-transclusion-blocks--add-by-follow
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -192,17 +192,21 @@ Called by `org-transclusion-blocks--add-by-follow' and
   "Extract content from BUF according to PLIST specifications.
 
 BUF is a buffer (possibly generated, not file-backed).
-PLIST is the keyword plist containing :lines.
+PLIST is the keyword plist containing :lines and :thing-at-point.
 SEARCH is optional string to locate extraction origin.
 
 When SEARCH is non-nil, find the first occurrence in BUF and use
-the beginning of that line as the origin for :lines extraction.
-All line numbers become relative to this origin.  When SEARCH is
-nil or not found, use `point-min' as origin.
+the beginning of that line as the origin for :lines and
+:thing-at-point extraction.
 
-:thing-at-point is not supported for generated buffers because the
-point position after :follow is not meaningful for semantic unit
-extraction.
+When :thing-at-point is in PLIST, call `bounds-of-thing-at-point'
+at the origin (or at the first non-whitespace character on the
+origin line) to determine extraction bounds.  The :end plist value
+controls repeat count for consecutive things.
+
+When :lines is in PLIST, extract line range relative to origin.
+
+:thing-at-point takes precedence over :lines when both present.
 
 Return payload plist with :src-content, :src-buf, :src-beg,
 :src-end, compatible with `org-transclusion-add-functions' protocol.
@@ -216,23 +220,43 @@ Called by `org-transclusion-blocks--add-by-follow'."
                              (line-beginning-position)
                            (point-min)))
                      (point-min)))
+           (thing-spec (plist-get plist :thing-at-point))
+           (thing (when thing-spec
+                    (intern (cadr (split-string thing-spec)))))
+           (end-spec (plist-get plist :end))
+           (count (if (and end-spec thing)
+                      (string-to-number
+                       (org-strip-quotes end-spec))
+                    1))
+           (thing-bounds
+            (when thing
+              (save-excursion
+                (goto-char origin)
+                (back-to-indentation)
+                (org-transclusion--bounds-of-n-things-at-point
+                 thing count))))
            (lines-spec (plist-get plist :lines))
            (range (when lines-spec (split-string lines-spec "-")))
            (lbeg (if range (string-to-number (car range)) 0))
            (lend (if range (string-to-number (cadr range)) 0))
-           (beg (if (> lbeg 0)
-                    (save-excursion
-                      (goto-char origin)
-                      (forward-line (1- lbeg))
-                      (point))
-                  origin))
-           (end (if (> lend 0)
-                    (save-excursion
-                      (goto-char origin)
-                      (forward-line (1- lend))
-                      (end-of-line)
-                      (min (1+ (point)) (point-max)))
-                  (point-max)))
+           ;; thing-at-point takes precedence over :lines
+           (beg (cond
+                 (thing-bounds (car thing-bounds))
+                 ((> lbeg 0)
+                  (save-excursion
+                    (goto-char origin)
+                    (forward-line (1- lbeg))
+                    (point)))
+                 (t origin)))
+           (end (cond
+                 (thing-bounds (cdr thing-bounds))
+                 ((> lend 0)
+                  (save-excursion
+                    (goto-char origin)
+                    (forward-line (1- lend))
+                    (end-of-line)
+                    (min (1+ (point)) (point-max))))
+                 (t (point-max))))
            (content (buffer-substring-no-properties beg end)))
       (list :src-content content
             :src-buf buf

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -277,15 +277,21 @@ Installed at depth -10 in `org-transclusion-add-functions'."
   "Install link handler functions into `org-transclusion-add-functions'.
 
 Prepend `org-transclusion-blocks--add-org-id-with-search' at depth -10
-before the upstream id: handler to fix :: search option splitting.
+before all other handlers to fix id: :: search option splitting.
 
-Append `org-transclusion-blocks--add-by-link-handler' at depth 80
-for explicit resolver registry (takes precedence over generic).
+Install `org-transclusion-blocks--add-by-link-handler' at depth -5
+for explicit resolver registry.
 
-Append `org-transclusion-blocks--add-by-generic-follow' at depth 90
-as fallback for `org-transclusion-blocks-generic-link-types'.
+Install `org-transclusion-blocks--add-by-generic-follow' at depth -4
+for defcustom-based follow resolution.
 
-Idempotent; safe to call multiple times."
+Both resolver handlers must precede `org-transclusion-add-src-lines'
+\(depth 0), which does not check link type and would attempt to open
+non-file paths directly via `find-file-noselect' when :lines is in
+the plist.
+
+Dedicated third-party handlers at depth 0 handle file: links
+produced by re-dispatch.  Idempotent; safe to call multiple times."
   (unless (memq 'org-transclusion-blocks--add-org-id-with-search
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions
@@ -295,12 +301,12 @@ Idempotent; safe to call multiple times."
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions
               #'org-transclusion-blocks--add-by-link-handler
-              80))
+              -5))
   (unless (memq 'org-transclusion-blocks--add-by-generic-follow
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions
               #'org-transclusion-blocks--add-by-generic-follow
-              90)))
+              -4)))
 
 ;; Install on load
 (org-transclusion-blocks--install-link-handlers)

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -188,34 +188,47 @@ Called by `org-transclusion-blocks--add-by-follow' and
                   result-buf))))
         (error nil)))))
 
-(defun org-transclusion-blocks--extract-lines-from-buffer (buf plist)
+(defun org-transclusion-blocks--extract-lines-from-buffer (buf plist &optional search)
   "Extract content from BUF according to PLIST specifications.
 
 BUF is a buffer (possibly generated, not file-backed).
-PLIST is the keyword plist containing :lines and :thing-at-point.
+PLIST is the keyword plist containing :lines.
+SEARCH is optional string to locate extraction origin.
 
-Apply :lines extraction when present.  :thing-at-point is not
-supported for generated buffers because the point position after
-:follow is not meaningful for semantic unit extraction.
+When SEARCH is non-nil, find the first occurrence in BUF and use
+the beginning of that line as the origin for :lines extraction.
+All line numbers become relative to this origin.  When SEARCH is
+nil or not found, use `point-min' as origin.
+
+:thing-at-point is not supported for generated buffers because the
+point position after :follow is not meaningful for semantic unit
+extraction.
 
 Return payload plist with :src-content, :src-buf, :src-beg,
 :src-end, compatible with `org-transclusion-add-functions' protocol.
 
 Called by `org-transclusion-blocks--add-by-follow'."
   (with-current-buffer buf
-    (let* ((lines-spec (plist-get plist :lines))
+    (let* ((origin (if search
+                       (save-excursion
+                         (goto-char (point-min))
+                         (if (search-forward search nil t)
+                             (line-beginning-position)
+                           (point-min)))
+                     (point-min)))
+           (lines-spec (plist-get plist :lines))
            (range (when lines-spec (split-string lines-spec "-")))
            (lbeg (if range (string-to-number (car range)) 0))
            (lend (if range (string-to-number (cadr range)) 0))
            (beg (if (> lbeg 0)
                     (save-excursion
-                      (goto-char (point-min))
+                      (goto-char origin)
                       (forward-line (1- lbeg))
                       (point))
-                  (point-min)))
+                  origin))
            (end (if (> lend 0)
                     (save-excursion
-                      (goto-char (point-min))
+                      (goto-char origin)
                       (forward-line (1- lend))
                       (end-of-line)
                       (min (1+ (point)) (point-max)))
@@ -250,7 +263,9 @@ Installed at depth -4 in `org-transclusion-add-functions'."
   ;; 2. Call :follow via `org-transclusion-blocks--invoke-follow'
   ;; 3. Inspect `buffer-file-name' on resulting buffer:
   ;;    - Non-nil: re-dispatch via `org-transclusion-blocks--redispatch-as-file'
+  ;;      (SEARCH appended as :: in re-dispatched file: link)
   ;;    - Nil: capture via `org-transclusion-blocks--extract-lines-from-buffer'
+  ;;      (SEARCH passed to shift extraction origin)
   (let ((type (org-element-property :type link)))
     (when (member type org-transclusion-blocks-follow-types)
       (pcase-let ((`(,path . ,search)
@@ -272,7 +287,7 @@ Installed at depth -4 in `org-transclusion-add-functions'."
            ;; Generated buffer: capture content directly
            (t
             (org-transclusion-blocks--extract-lines-from-buffer
-             result-buf plist))))))))
+             result-buf plist search))))))))
 
 ;;;; Explicit Resolver Dispatch
 

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -132,18 +132,24 @@ the existing :path and :search-option values."
 Call the :follow function registered in `org-link-parameters' for TYPE,
 capture the resulting buffer, and return its variable `buffer-file-name'.
 
-Return nil if:
-- No :follow function registered for TYPE
-- :follow function errors
-- Resulting buffer has no file association
+Return nil if no :follow function is registered, resolution errors,
+or the resulting buffer has no file association.
+
+Try calling with two arguments (PATH ARG) first, falling back to
+one argument (PATH) for :follow functions that do not accept an
+optional prefix argument.
 
 Uses `save-window-excursion' to contain side effects of :follow.
+
 Called by `org-transclusion-blocks--add-by-generic-follow'."
   (when-let* ((follow-fn (org-link-get-parameter type :follow)))
     (condition-case nil
         (save-window-excursion
           (save-excursion
-            (funcall follow-fn path nil)
+            (condition-case nil
+                (funcall follow-fn path nil)
+              (wrong-number-of-arguments
+               (funcall follow-fn path)))
             buffer-file-name))
       (error nil))))
 

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -27,30 +27,38 @@
 ;; Extends org-transclusion to handle link types beyond file: and id:.
 ;;
 ;; org-transclusion's built-in handlers only resolve file: and id: links.
-;; This file adds two resolution mechanisms that convert any file-backed
-;; link type to a file: link and re-dispatch, preserving :lines,
-;; :thing-at-point, and all other transclusion keywords.
+;; This file provides a unified resolution mechanism that converts any
+;; link type with a :follow function into transcludable content.
 ;;
-;; Generic follow-based resolution (zero configuration):
+;; Resolution strategy:
 ;;
-;;     (add-to-list 'org-transclusion-blocks-generic-link-types "my-type")
+;; 1. Call the link type's :follow function from `org-link-parameters'
+;; 2. Inspect the resulting buffer:
+;;    - File-backed buffer: re-dispatch as file: link (preserves
+;;      upstream :lines and :thing-at-point handling)
+;;    - Generated buffer: capture content directly with internal
+;;      line extraction
 ;;
-;; Works for any link type whose :follow function opens a file buffer.
-;; Defaults to ("denote" "roam").
+;; Zero-configuration usage for types in
+;; `org-transclusion-blocks-follow-types' (default: "info"):
 ;;
-;; Explicit resolver registry (for non-file-backed links):
+;;     #+HEADER: :transclude [[info:emacs]]
+;;     #+HEADER: :transclude-lines 1-30
+;;     #+begin_src text
+;;     #+end_src
+;;
+;; Other follow-based types (help, denote, var, etc) require adding
+;; to `org-transclusion-blocks-follow-types' by the user.
+;;
+;; Explicit resolver registry for non-follow-based resolution:
 ;;
 ;;     (org-transclusion-blocks-register-link-handler
 ;;      "my-type"
 ;;      (lambda (path) (my-resolve-to-file path)))
 ;;
-;; Also fixes id: links with ::search options.  `org-id-open' splits
-;; :: from the path internally, but `org-transclusion-add-org-id'
-;; passes the unsplit :path directly to `org-id-find', which fails.
-;;
 ;; Key functions:
 ;; - `org-transclusion-blocks-register-link-handler' - Register resolver
-;; - `org-transclusion-blocks-generic-link-types' - Defcustom for types
+;; - `org-transclusion-blocks-follow-types' - Defcustom for types
 
 ;;; Code:
 
@@ -58,17 +66,32 @@
 
 ;;;; Customization
 
-(defcustom org-transclusion-blocks-generic-link-types '("denote" "roam")
-  "Link types resolved via their :follow function from `org-link-parameters'.
+(defcustom org-transclusion-blocks-follow-types
+  '("info")
+  "Link types resolved via their :follow function for transclusion.
 
-Each entry is a link type string.  The type's :follow function must open
-a file-visiting buffer.  Types whose :follow opens a browser or external
-application are not supported; use
-`org-transclusion-blocks-register-link-handler' instead.
+Each entry is a link type string.  When a transclusion targets one of
+these types, the handler calls the type's :follow function from
+`org-link-parameters' and inspects the resulting buffer:
 
-Handled by `org-transclusion-blocks--add-by-generic-follow' at depth 90
-in `org-transclusion-add-functions'.  Dedicated handlers at depth 0
-take precedence."
+- File-backed buffer (variable `buffer-file-name' non-nil): re-dispatch as a
+  file: link, preserving upstream :lines and :thing-at-point handling
+  via `org-transclusion-add-src-lines'.
+
+- Generated buffer (variable `buffer-file-name' nil): capture buffer content
+  directly and apply :lines extraction internally.
+
+Types whose :follow function opens an external application (browser,
+mail client) are not supported.  Use
+`org-transclusion-blocks-register-link-handler' for types needing
+custom resolution without calling :follow.
+
+Handled by `org-transclusion-blocks--add-by-follow' at depth -4 in
+`org-transclusion-add-functions'.  Explicit resolver handlers at
+depth -5 take precedence.
+
+Queried by `org-transclusion-blocks--source-is-org-p' for Org
+escape detection."
   :type '(repeat string)
   :group 'org-transclusion-blocks
   :package-version '(org-transclusion-blocks . "0.5.0"))
@@ -94,7 +117,7 @@ TYPE is a link type string (e.g. \"denote\").
 RESOLVER receives link path string, returns absolute file path or nil.
 Check package availability inside RESOLVER via `fboundp'.
 
-Takes precedence over `org-transclusion-blocks-generic-link-types'.
+Takes precedence over `org-transclusion-blocks-follow-types'.
 Populates `org-transclusion-blocks--link-handlers'."
   (setf (alist-get type org-transclusion-blocks--link-handlers
                    nil nil #'string=)
@@ -105,14 +128,20 @@ Populates `org-transclusion-blocks--link-handlers'."
 (defun org-transclusion-blocks--split-path-search (link)
   "Split path and search option from LINK element.
 
+LINK is an `org-element' link object.
+
 `org-element' does not parse :: separators for non-file link types.
 The entire \"path::search\" string goes into :path with
 :search-option nil.
 
 Return cons (PATH . SEARCH-OPTION) where SEARCH-OPTION may be nil.
 
-For file: links where org-element already splits correctly, return
-the existing :path and :search-option values."
+For file: links where `org-element' already splits correctly, return
+the existing :path and :search-option values.
+
+Called by `org-transclusion-blocks--add-by-follow',
+`org-transclusion-blocks--add-by-link-handler', and
+`org-transclusion-blocks--add-org-id-with-search'."
   (let ((full-path (org-element-property :path link))
         (search-option (org-element-property :search-option link)))
     (if search-option
@@ -124,71 +153,134 @@ the existing :path and :search-option values."
                 (match-string 2 full-path))
         (cons full-path nil)))))
 
-;;;; Generic Follow-Based Resolution
+;;;; Follow-Based Resolution
 
-(defun org-transclusion-blocks--resolve-link-via-follow (type path)
-  "Resolve link of TYPE with PATH to a file path via :follow function.
+(defun org-transclusion-blocks--invoke-follow (type path)
+  "Call :follow function for link TYPE with PATH string.
 
-Call the :follow function registered in `org-link-parameters' for TYPE,
-capture the resulting buffer, and return its variable `buffer-file-name'.
+TYPE is a link type string registered in `org-link-parameters'.
+PATH is the link path with :: search option already stripped.
 
-Return nil if no :follow function is registered, resolution errors,
-or the resulting buffer has no file association.
+Return the resulting buffer, or nil if :follow is not registered,
+signals an error, or the resulting buffer is the same as the
+buffer before invocation (indicating :follow had no effect).
 
 Try calling with two arguments (PATH ARG) first, falling back to
 one argument (PATH) for :follow functions that do not accept an
 optional prefix argument.
 
-Uses `save-window-excursion' to contain side effects of :follow.
+Uses `save-window-excursion' to contain window side effects.
 
-Called by `org-transclusion-blocks--add-by-generic-follow'."
+Called by `org-transclusion-blocks--add-by-follow' and
+`org-transclusion-blocks--source-is-org-p'."
   (when-let* ((follow-fn (org-link-get-parameter type :follow)))
-    (condition-case nil
-        (save-window-excursion
-          (save-excursion
-            (condition-case nil
-                (funcall follow-fn path nil)
-              (wrong-number-of-arguments
-               (funcall follow-fn path)))
-            buffer-file-name))
-      (error nil))))
+    (let ((orig-buf (current-buffer)))
+      (condition-case nil
+          (save-window-excursion
+            (save-excursion
+              (condition-case nil
+                  (funcall follow-fn path nil)
+                (wrong-number-of-arguments
+                 (funcall follow-fn path)))
+              (let ((result-buf (current-buffer)))
+                ;; Return nil if :follow did not switch buffers
+                (unless (eq result-buf orig-buf)
+                  result-buf))))
+        (error nil)))))
 
-(defun org-transclusion-blocks--add-by-generic-follow (link plist)
-  "Resolve LINK via :follow function and re-dispatch for PLIST.
+(defun org-transclusion-blocks--extract-lines-from-buffer (buf plist)
+  "Extract content from BUF according to PLIST specifications.
 
-Handle link types listed in `org-transclusion-blocks-generic-link-types'.
-Resolve to a file path by calling the link type's :follow function
-from `org-link-parameters', construct a file: link preserving any
-search option, and re-dispatch through `org-transclusion-add-functions'.
+BUF is a buffer (possibly generated, not file-backed).
+PLIST is the keyword plist containing :lines and :thing-at-point.
 
-Split :: from path manually via `org-transclusion-blocks--split-path-search'
-because `org-element' does not parse :: separators for non-file link types.
+Apply :lines extraction when present.  :thing-at-point is not
+supported for generated buffers because the point position after
+:follow is not meaningful for semantic unit extraction.
 
-Return payload plist, or nil if link type is not in
-`org-transclusion-blocks-generic-link-types' or resolution fails.
+Return payload plist with :src-content, :src-buf, :src-beg,
+:src-end, compatible with `org-transclusion-add-functions' protocol.
 
-Uses `org-transclusion-blocks--split-path-search' for :: splitting.
-Uses `org-transclusion-blocks--resolve-link-via-follow' for resolution.
-Delegates to `org-transclusion-blocks--redispatch-as-file'."
+Called by `org-transclusion-blocks--add-by-follow'."
+  (with-current-buffer buf
+    (let* ((lines-spec (plist-get plist :lines))
+           (range (when lines-spec (split-string lines-spec "-")))
+           (lbeg (if range (string-to-number (car range)) 0))
+           (lend (if range (string-to-number (cadr range)) 0))
+           (beg (if (> lbeg 0)
+                    (save-excursion
+                      (goto-char (point-min))
+                      (forward-line (1- lbeg))
+                      (point))
+                  (point-min)))
+           (end (if (> lend 0)
+                    (save-excursion
+                      (goto-char (point-min))
+                      (forward-line (1- lend))
+                      (end-of-line)
+                      (min (1+ (point)) (point-max)))
+                  (point-max)))
+           (content (buffer-substring-no-properties beg end)))
+      (list :src-content content
+            :src-buf buf
+            :src-beg beg
+            :src-end end
+            :tc-type "follow-capture"))))
+
+(defun org-transclusion-blocks--add-by-follow (link plist)
+  "Resolve LINK via :follow function and return payload for PLIST.
+
+LINK is an `org-element' link object.
+PLIST is keyword plist passed unchanged to handlers.
+
+Handle link types listed in `org-transclusion-blocks-follow-types'.
+Return payload plist, or nil if link type is not listed.
+
+Buffer cleanup is NOT performed here.  See implementation notes.
+
+Installed at depth -4 in `org-transclusion-add-functions'."
+  ;; This function is on a public hook where callers expect :src-buf
+  ;; to remain live for overlay creation and live-sync tracking.
+  ;; Buffer cleanup is the responsibility of the calling site:
+  ;; - `org-transclusion-blocks--fetch-content' for block transclusions
+  ;; - `org-transclusion--add' for standard #+transclude: usage
+  ;;
+  ;; Resolution strategy:
+  ;; 1. Split :: from path via `org-transclusion-blocks--split-path-search'
+  ;; 2. Call :follow via `org-transclusion-blocks--invoke-follow'
+  ;; 3. Inspect `buffer-file-name' on resulting buffer:
+  ;;    - Non-nil: re-dispatch via `org-transclusion-blocks--redispatch-as-file'
+  ;;    - Nil: capture via `org-transclusion-blocks--extract-lines-from-buffer'
   (let ((type (org-element-property :type link)))
-    (when (member type org-transclusion-blocks-generic-link-types)
+    (when (member type org-transclusion-blocks-follow-types)
       (pcase-let ((`(,path . ,search)
                    (org-transclusion-blocks--split-path-search link)))
-        (let ((file-path
-               (org-transclusion-blocks--resolve-link-via-follow type path)))
-          (if (not (and file-path (file-exists-p file-path)))
-              (progn
-                (message
-                 "org-transclusion-blocks: %s link %S could not be resolved to a file"
-                 type path)
-                '(:src-content nil))
+        (let ((result-buf (org-transclusion-blocks--invoke-follow type path)))
+          (cond
+           ;; :follow did not produce a buffer
+           ((not result-buf)
+            (message
+             "org-transclusion-blocks: %s link %S could not be resolved"
+             type path)
+            '(:src-content nil))
+
+           ;; File-backed buffer: re-dispatch as file: link
+           ((buffer-file-name result-buf)
             (org-transclusion-blocks--redispatch-as-file
-             file-path search plist)))))))
+             (buffer-file-name result-buf) search plist))
+
+           ;; Generated buffer: capture content directly
+           (t
+            (org-transclusion-blocks--extract-lines-from-buffer
+             result-buf plist))))))))
 
 ;;;; Explicit Resolver Dispatch
 
 (defun org-transclusion-blocks--add-by-link-handler (link plist)
   "Resolve LINK via explicit resolver registry and re-dispatch for PLIST.
+
+LINK is an `org-element' link object.
+PLIST is keyword plist passed unchanged to handlers.
 
 Check `org-transclusion-blocks--link-handlers' for a resolver matching
 the link type.  Return payload plist, or nil if no handler matches.
@@ -196,7 +288,7 @@ the link type.  Return payload plist, or nil if no handler matches.
 Uses `org-transclusion-blocks--split-path-search' for :: splitting.
 Delegates to `org-transclusion-blocks--redispatch-as-file'.
 
-Installed at depth 80 in `org-transclusion-add-functions'."
+Installed at depth -5 in `org-transclusion-add-functions'."
   (let* ((type (org-element-property :type link))
          (resolver (alist-get type org-transclusion-blocks--link-handlers
                               nil nil #'string=)))
@@ -230,7 +322,7 @@ PLIST is keyword plist passed unchanged to handlers.
 
 Return payload plist from the successful handler, or nil.
 
-Called by `org-transclusion-blocks--add-by-generic-follow',
+Called by `org-transclusion-blocks--add-by-follow',
 `org-transclusion-blocks--add-by-link-handler', and
 `org-transclusion-blocks--add-org-id-with-search'."
   (let* ((link-target (if search
@@ -247,6 +339,9 @@ Called by `org-transclusion-blocks--add-by-generic-follow',
 
 (defun org-transclusion-blocks--add-org-id-with-search (link plist)
   "Handle id: LINK containing :: search option for PLIST.
+
+LINK is an `org-element' link object.
+PLIST is keyword plist passed unchanged to handlers.
 
 Return nil for id: links without :: to let upstream handle those.
 Return (:src-content nil) on UUID lookup failure to prevent
@@ -282,8 +377,8 @@ before all other handlers to fix id: :: search option splitting.
 Install `org-transclusion-blocks--add-by-link-handler' at depth -5
 for explicit resolver registry.
 
-Install `org-transclusion-blocks--add-by-generic-follow' at depth -4
-for defcustom-based follow resolution.
+Install `org-transclusion-blocks--add-by-follow' at depth -4
+for unified follow-based resolution.
 
 Both resolver handlers must precede `org-transclusion-add-src-lines'
 \(depth 0), which does not check link type and would attempt to open
@@ -291,7 +386,12 @@ non-file paths directly via `find-file-noselect' when :lines is in
 the plist.
 
 Dedicated third-party handlers at depth 0 handle file: links
-produced by re-dispatch.  Idempotent; safe to call multiple times."
+produced by re-dispatch.  Idempotent; safe to call multiple times.
+
+Called at load time by the top-level form at end of file."
+  ;; Remove old handler if present (renamed from generic-follow)
+  (remove-hook 'org-transclusion-add-functions
+               'org-transclusion-blocks--add-by-generic-follow)
   (unless (memq 'org-transclusion-blocks--add-org-id-with-search
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions
@@ -302,10 +402,10 @@ produced by re-dispatch.  Idempotent; safe to call multiple times."
     (add-hook 'org-transclusion-add-functions
               #'org-transclusion-blocks--add-by-link-handler
               -5))
-  (unless (memq 'org-transclusion-blocks--add-by-generic-follow
+  (unless (memq 'org-transclusion-blocks--add-by-follow
                 org-transclusion-add-functions)
     (add-hook 'org-transclusion-add-functions
-              #'org-transclusion-blocks--add-by-generic-follow
+              #'org-transclusion-blocks--add-by-follow
               -4)))
 
 ;; Install on load

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -1,0 +1,303 @@
+;;; org-transclusion-blocks-link-handlers.el --- Link type resolvers -*- lexical-binding: t; -*-
+
+;; Author: Gino Cornejo
+;; Maintainer: Gino Cornejo <gggion123@gmail.com>
+;; URL: https://github.com/gggion/org-transclusion-blocks
+;; Keywords: hypermedia vc
+
+;; This file is part of org-transclusion-blocks.
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Extends org-transclusion to handle link types beyond file: and id:.
+;;
+;; org-transclusion's built-in handlers only resolve file: and id: links.
+;; This file adds two resolution mechanisms that convert any file-backed
+;; link type to a file: link and re-dispatch, preserving :lines,
+;; :thing-at-point, and all other transclusion keywords.
+;;
+;; Generic follow-based resolution (zero configuration):
+;;
+;;     (add-to-list 'org-transclusion-blocks-generic-link-types "my-type")
+;;
+;; Works for any link type whose :follow function opens a file buffer.
+;; Defaults to ("denote" "roam").
+;;
+;; Explicit resolver registry (for non-file-backed links):
+;;
+;;     (org-transclusion-blocks-register-link-handler
+;;      "my-type"
+;;      (lambda (path) (my-resolve-to-file path)))
+;;
+;; Also fixes id: links with ::search options.  `org-id-open' splits
+;; :: from the path internally, but `org-transclusion-add-org-id'
+;; passes the unsplit :path directly to `org-id-find', which fails.
+;;
+;; Key functions:
+;; - `org-transclusion-blocks-register-link-handler' - Register resolver
+;; - `org-transclusion-blocks-generic-link-types' - Defcustom for types
+
+;;; Code:
+
+(require 'org-transclusion)
+
+;;;; Customization
+
+(defcustom org-transclusion-blocks-generic-link-types '("denote" "roam")
+  "Link types resolved via their :follow function from `org-link-parameters'.
+
+Each entry is a link type string.  The type's :follow function must open
+a file-visiting buffer.  Types whose :follow opens a browser or external
+application are not supported; use
+`org-transclusion-blocks-register-link-handler' instead.
+
+Handled by `org-transclusion-blocks--add-by-generic-follow' at depth 90
+in `org-transclusion-add-functions'.  Dedicated handlers at depth 0
+take precedence."
+  :type '(repeat string)
+  :group 'org-transclusion-blocks
+  :package-version '(org-transclusion-blocks . "0.5.0"))
+
+;;;; Explicit Resolver Registry
+
+(defvar org-transclusion-blocks--link-handlers nil
+  "Alist mapping link type strings to resolver functions.
+
+Each entry: (TYPE-STRING . RESOLVER-FUNCTION)
+
+RESOLVER-FUNCTION receives link path string (:: search already stripped)
+and returns absolute file path, or nil.
+
+Populated by `org-transclusion-blocks-register-link-handler'.
+Queried by `org-transclusion-blocks--add-by-link-handler'.
+Queried by `org-transclusion-blocks--source-is-org-p'.")
+
+(defun org-transclusion-blocks-register-link-handler (type resolver)
+  "Register RESOLVER for link TYPE in explicit resolver registry.
+
+TYPE is a link type string (e.g. \"denote\").
+RESOLVER receives link path string, returns absolute file path or nil.
+Check package availability inside RESOLVER via `fboundp'.
+
+Takes precedence over `org-transclusion-blocks-generic-link-types'.
+Populates `org-transclusion-blocks--link-handlers'."
+  (setf (alist-get type org-transclusion-blocks--link-handlers
+                   nil nil #'string=)
+        resolver))
+
+;;;; Path Splitting
+
+(defun org-transclusion-blocks--split-path-search (link)
+  "Split path and search option from LINK element.
+
+`org-element' does not parse :: separators for non-file link types.
+The entire \"path::search\" string goes into :path with
+:search-option nil.
+
+Return cons (PATH . SEARCH-OPTION) where SEARCH-OPTION may be nil.
+
+For file: links where org-element already splits correctly, return
+the existing :path and :search-option values."
+  (let ((full-path (org-element-property :path link))
+        (search-option (org-element-property :search-option link)))
+    (if search-option
+        ;; org-element already split (file: links)
+        (cons full-path search-option)
+      ;; Manual split for non-file link types
+      (if (string-match "\\`\\(.*?\\)::\\(.+\\)\\'" full-path)
+          (cons (match-string 1 full-path)
+                (match-string 2 full-path))
+        (cons full-path nil)))))
+
+;;;; Generic Follow-Based Resolution
+
+(defun org-transclusion-blocks--resolve-link-via-follow (type path)
+  "Resolve link of TYPE with PATH to a file path via :follow function.
+
+Call the :follow function registered in `org-link-parameters' for TYPE,
+capture the resulting buffer, and return its variable `buffer-file-name'.
+
+Return nil if:
+- No :follow function registered for TYPE
+- :follow function errors
+- Resulting buffer has no file association
+
+Uses `save-window-excursion' to contain side effects of :follow.
+Called by `org-transclusion-blocks--add-by-generic-follow'."
+  (when-let* ((follow-fn (org-link-get-parameter type :follow)))
+    (condition-case nil
+        (save-window-excursion
+          (save-excursion
+            (funcall follow-fn path nil)
+            buffer-file-name))
+      (error nil))))
+
+(defun org-transclusion-blocks--add-by-generic-follow (link plist)
+  "Resolve LINK via :follow function and re-dispatch for PLIST.
+
+Handle link types listed in `org-transclusion-blocks-generic-link-types'.
+Resolve to a file path by calling the link type's :follow function
+from `org-link-parameters', construct a file: link preserving any
+search option, and re-dispatch through `org-transclusion-add-functions'.
+
+Split :: from path manually via `org-transclusion-blocks--split-path-search'
+because `org-element' does not parse :: separators for non-file link types.
+
+Return payload plist, or nil if link type is not in
+`org-transclusion-blocks-generic-link-types' or resolution fails.
+
+Uses `org-transclusion-blocks--split-path-search' for :: splitting.
+Uses `org-transclusion-blocks--resolve-link-via-follow' for resolution.
+Delegates to `org-transclusion-blocks--redispatch-as-file'."
+  (let ((type (org-element-property :type link)))
+    (when (member type org-transclusion-blocks-generic-link-types)
+      (pcase-let ((`(,path . ,search)
+                   (org-transclusion-blocks--split-path-search link)))
+        (let ((file-path
+               (org-transclusion-blocks--resolve-link-via-follow type path)))
+          (if (not (and file-path (file-exists-p file-path)))
+              (progn
+                (message
+                 "org-transclusion-blocks: %s link %S could not be resolved to a file"
+                 type path)
+                '(:src-content nil))
+            (org-transclusion-blocks--redispatch-as-file
+             file-path search plist)))))))
+
+;;;; Explicit Resolver Dispatch
+
+(defun org-transclusion-blocks--add-by-link-handler (link plist)
+  "Resolve LINK via explicit resolver registry and re-dispatch for PLIST.
+
+Check `org-transclusion-blocks--link-handlers' for a resolver matching
+the link type.  Return payload plist, or nil if no handler matches.
+
+Uses `org-transclusion-blocks--split-path-search' for :: splitting.
+Delegates to `org-transclusion-blocks--redispatch-as-file'.
+
+Installed at depth 80 in `org-transclusion-add-functions'."
+  (let* ((type (org-element-property :type link))
+         (resolver (alist-get type org-transclusion-blocks--link-handlers
+                              nil nil #'string=)))
+    (when resolver
+      (pcase-let ((`(,path . ,search)
+                   (org-transclusion-blocks--split-path-search link)))
+        (let ((file-path (condition-case err
+                             (funcall resolver path)
+                           (error
+                            (message
+                             "org-transclusion-blocks: %s resolver error: %s"
+                             type (error-message-string err))
+                            nil))))
+          (if (not (and file-path (file-exists-p file-path)))
+              (progn
+                (message
+                 "org-transclusion-blocks: %s link %S could not be resolved"
+                 type path)
+                '(:src-content nil))
+            (org-transclusion-blocks--redispatch-as-file
+             file-path search plist)))))))
+
+;;;; Re-Dispatch Utility
+
+(defun org-transclusion-blocks--redispatch-as-file (file-path search plist)
+  "Construct file: link to FILE-PATH with SEARCH and re-dispatch for PLIST.
+
+FILE-PATH is absolute path to target file.
+SEARCH is search option string or nil.
+PLIST is keyword plist passed unchanged to handlers.
+
+Return payload plist from the successful handler, or nil.
+
+Called by `org-transclusion-blocks--add-by-generic-follow',
+`org-transclusion-blocks--add-by-link-handler', and
+`org-transclusion-blocks--add-org-id-with-search'."
+  (let* ((link-target (if search
+                          (concat "file:" file-path "::" search)
+                        (concat "file:" file-path)))
+         (file-link-str (org-link-make-string link-target))
+         (file-link (org-transclusion-wrap-path-to-link file-link-str)))
+    (run-hook-with-args-until-success
+     'org-transclusion-add-functions
+     file-link
+     plist)))
+
+;;;; id: Links with Search Options
+
+(defun org-transclusion-blocks--add-org-id-with-search (link plist)
+  "Handle id: LINK containing :: search option for PLIST.
+
+Return nil for id: links without :: to let upstream handle those.
+Return (:src-content nil) on UUID lookup failure to prevent
+fallthrough to upstream `org-transclusion-add-org-id'.
+
+Uses `org-transclusion-blocks--split-path-search' for :: splitting.
+Resolves UUID via `org-id-find'.
+Delegates to `org-transclusion-blocks--redispatch-as-file'.
+
+Installed at depth -10 in `org-transclusion-add-functions'."
+  (when (string= "id" (org-element-property :type link))
+    (pcase-let ((`(,id . ,search)
+                 (org-transclusion-blocks--split-path-search link)))
+      (when search
+        (let ((found (ignore-errors (org-id-find id))))
+          (if (not found)
+              (progn
+                (message
+                 "No transclusion done for ID %s at point %d, line %d"
+                 id (point) (org-current-line))
+                '(:src-content nil))
+            (org-transclusion-blocks--redispatch-as-file
+             (car found) search plist)))))))
+
+;;;; Installation
+
+(defun org-transclusion-blocks--install-link-handlers ()
+  "Install link handler functions into `org-transclusion-add-functions'.
+
+Prepend `org-transclusion-blocks--add-org-id-with-search' at depth -10
+before the upstream id: handler to fix :: search option splitting.
+
+Append `org-transclusion-blocks--add-by-link-handler' at depth 80
+for explicit resolver registry (takes precedence over generic).
+
+Append `org-transclusion-blocks--add-by-generic-follow' at depth 90
+as fallback for `org-transclusion-blocks-generic-link-types'.
+
+Idempotent; safe to call multiple times."
+  (unless (memq 'org-transclusion-blocks--add-org-id-with-search
+                org-transclusion-add-functions)
+    (add-hook 'org-transclusion-add-functions
+              #'org-transclusion-blocks--add-org-id-with-search
+              -10))
+  (unless (memq 'org-transclusion-blocks--add-by-link-handler
+                org-transclusion-add-functions)
+    (add-hook 'org-transclusion-add-functions
+              #'org-transclusion-blocks--add-by-link-handler
+              80))
+  (unless (memq 'org-transclusion-blocks--add-by-generic-follow
+                org-transclusion-add-functions)
+    (add-hook 'org-transclusion-add-functions
+              #'org-transclusion-blocks--add-by-generic-follow
+              90)))
+
+;; Install on load
+(org-transclusion-blocks--install-link-handlers)
+
+(provide 'org-transclusion-blocks-link-handlers)
+;;; org-transclusion-blocks-link-handlers.el ends here

--- a/org-transclusion-blocks-link-handlers.el
+++ b/org-transclusion-blocks-link-handlers.el
@@ -61,8 +61,13 @@
 ;; - `org-transclusion-blocks-follow-types' - Defcustom for types
 
 ;;; Code:
+(require 'org-element)
+(require 'ol)
 
-(require 'org-transclusion)
+(declare-function org-transclusion-wrap-path-to-link "org-transclusion")
+(declare-function org-transclusion-keyword-string-to-plist "org-transclusion")
+(declare-function org-transclusion--bounds-of-n-things-at-point "org-transclusion")
+(defvar org-transclusion-add-functions)
 
 ;;;; Customization
 

--- a/org-transclusion-blocks-types.el
+++ b/org-transclusion-blocks-types.el
@@ -86,11 +86,13 @@
 
 ;;; Code:
 
-(require 'org-transclusion)
 (require 'org-element)
 (require 'ol)
 (require 'org-macs)
 (require 'cl-lib)
+
+(declare-function org-transclusion-keyword-string-to-plist "org-transclusion")
+(declare-function org-transclusion-wrap-path-to-link "org-transclusion")
 
 ;;;; Type Registry State
 

--- a/org-transclusion-blocks-types.el
+++ b/org-transclusion-blocks-types.el
@@ -2,7 +2,7 @@
 
 ;; Author: Gino Cornejo
 ;; Maintainer: Gino Cornejo <gggion123@gmail.com>
-;; Homepage: https://github.com/gggion/org-transclusion-blocks
+;; URL: https://github.com/gggion/org-transclusion-blocks
 
 ;; This file is part of org-transclusion-blocks.
 

--- a/org-transclusion-blocks-types.el
+++ b/org-transclusion-blocks-types.el
@@ -124,6 +124,21 @@ returns raw link string (without [[ ]] brackets).
 Populated via `org-transclusion-blocks-register-type'.
 Used by `org-transclusion-blocks--construct-link'.")
 
+(defvar org-transclusion-blocks--type-content-handlers nil
+  "Alist mapping link types to content handler functions.
+
+Each entry: (TYPE . CONTENT-HANDLER-FUNC)
+
+CONTENT-HANDLER-FUNC receives (COMPONENTS PLIST) and returns
+payload plist or nil.
+
+When present for a type, `org-transclusion-blocks-add' calls
+the handler directly instead of dispatching through
+`org-transclusion-add-functions'.
+
+Populated via `org-transclusion-blocks-register-type'.
+Queried by `org-transclusion-blocks--fetch-content-via-handler'.")
+
 ;;;; Validator Composition Utilities
 
 (defun org-transclusion-blocks-make-non-empty-validator (component-description)
@@ -315,10 +330,11 @@ Called by `org-transclusion-blocks--pre-validate-headers'."
 
 ;;;; Type Registry API
 
-(defun org-transclusion-blocks-register-type (type component-spec constructor)
-  "Register link TYPE with COMPONENT-SPEC and CONSTRUCTOR.
+(defun org-transclusion-blocks-register-type (type component-spec constructor
+                                              &optional content-handler)
+  "Register link TYPE with COMPONENT-SPEC, CONSTRUCTOR, and CONTENT-HANDLER.
 
-TYPE is symbol naming link type (e.g., \\='my-link).
+TYPE is symbol naming link type (e.g., \\='orgit-file).
 
 COMPONENT-SPEC is plist mapping semantic component names to metadata:
   (:semantic-name (:header :header-keyword
@@ -330,27 +346,52 @@ COMPONENT-SPEC is plist mapping semantic component names to metadata:
 
 CONSTRUCTOR receives plist of validated components,
 returns raw link string (without [[ ]] brackets).
+Required for link construction even when CONTENT-HANDLER is present,
+because link strings appear in #+transclude: lines for keyword
+plist parsing.
 
-Example:
+CONTENT-HANDLER, when non-nil, is a function receiving two arguments:
+  (COMPONENTS PLIST)
 
-  (org-transclusion-blocks-register-type
-   \\='my-type
-   \\='(:path (:header :my-path
-              :validator my-validator-fn
-              :required t))
-   (lambda (components)
-     (format \"my-type:%s\" (plist-get components :path))))
+COMPONENTS is plist of validated, expanded component values
+  (same as CONSTRUCTOR receives).
+PLIST is keyword plist from `org-transclusion-blocks--params-to-plist'
+  containing :link, :lines, :thing-at-point, :end, etc.
+
+CONTENT-HANDLER returns a payload plist compatible with
+`org-transclusion-add-functions' protocol:
+  (:src-content STRING
+   :src-buf BUFFER
+   :src-beg INTEGER-OR-MARKER
+   :src-end INTEGER-OR-MARKER
+   :tc-type STRING)
+
+Or nil if content cannot be fetched.
+
+When CONTENT-HANDLER is present, `org-transclusion-blocks-add'
+calls it directly instead of dispatching through
+`org-transclusion-add-functions'.  The constructed link string
+is still available in PLIST as :link and :constructed-link.
+
+When CONTENT-HANDLER is nil, the type uses the standard pipeline:
+CONSTRUCTOR builds a link string, which is dispatched through
+`org-transclusion-add-functions' for resolution by follow handlers,
+explicit resolvers, or upstream handlers.
 
 Overwrites existing TYPE registration if present.
 
-Populates `org-transclusion-blocks--type-components' and
-`org-transclusion-blocks--type-constructors'.
+Populates `org-transclusion-blocks--type-components',
+`org-transclusion-blocks--type-constructors', and
+`org-transclusion-blocks--type-content-handlers'.
 
 Returns TYPE symbol."
   (setf (alist-get type org-transclusion-blocks--type-components)
         component-spec)
   (setf (alist-get type org-transclusion-blocks--type-constructors)
         constructor)
+  (when content-handler
+    (setf (alist-get type org-transclusion-blocks--type-content-handlers)
+          content-handler))
   type)
 
 ;;;; Component Extraction
@@ -558,6 +599,7 @@ Shows:
 - Variable expansion support
 - Interaction constraints (required, shadowed-by, requires, conflicts)
 - Constructor function
+- Content handler (if registered)
 - Usage example
 
 See `org-transclusion-blocks-list-types' for available types."
@@ -612,6 +654,15 @@ See `org-transclusion-blocks-list-types' for available types."
                                             (mapconcat #'symbol-name conflicts ", "))))))
             (unless has-interactions
               (insert "  (none)\n")))
+
+          (insert "\nResolution:\n")
+          (if (alist-get type org-transclusion-blocks--type-content-handlers)
+              (progn
+                (insert "  Content handler: direct (bypasses hook dispatch)\n")
+                (insert (format "  Handler: %s\n"
+                                (alist-get type
+                                           org-transclusion-blocks--type-content-handlers))))
+            (insert "  Standard pipeline: constructor -> link -> hook dispatch\n"))
 
           (when-let ((ctor (alist-get type org-transclusion-blocks--type-constructors)))
             (insert (format "\nConstructor: %s\n" ctor)))

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -135,15 +135,6 @@ Set to 0 to disable indicator."
   :group 'org-transclusion-blocks
   :package-version '(org-transclusion-blocks . "0.1.0"))
 
-(defcustom org-transclusion-blocks-timestamp-property 'org-transclusion-blocks-fetched
-  "Text property name for storing fetch timestamp.
-
-Applied to transcluded content in block body.
-Used for future refresh functionality."
-  :type 'symbol
-  :group 'org-transclusion-blocks
-  :package-version '(org-transclusion-blocks . "0.1.0"))
-
 (defcustom org-transclusion-blocks-show-interaction-warnings t
   "Whether to show warnings for component interactions.
 
@@ -192,63 +183,6 @@ Does not affect non-Org sources (Python files, text files, etc.)."
   :group 'org-transclusion-blocks
   :package-version '(org-transclusion-blocks . "0.2.0"))
 
-
-;;;; Internal Variables
-
-(defvar org-transclusion-blocks--last-fetch-time nil
-  "Timestamp of most recent successful content fetch.
-
-Buffer-local.
-Used by `org-transclusion-blocks--show-indicator'.")
-(make-variable-buffer-local 'org-transclusion-blocks--last-fetch-time)
-
-(defvar-local org-transclusion-blocks--last-payload nil
-  "Cached payload from most recent content fetch.
-Used by metadata application to avoid re-fetching.")
-
-(defvar org-transclusion-blocks-yank-excluded-properties
-  '(org-transclusion-blocks-keyword
-    org-transclusion-blocks-link
-    org-transclusion-blocks-max-line
-    org-transclusion-blocks-fetched
-    org-transclusion-blocks-id
-    org-transclusion-blocks-tc-type
-    org-transclusion-blocks-src-overlay)
-  "Text properties excluded from yank operations.
-
-These properties are implementation details for org-transclusion-blocks
-and should not propagate when users copy transcluded content.
-
-Unlike org-transclusion.el, we apply this exclusion permanently rather
-than during activation/deactivation cycles, since block transclusions
-are one-shot operations without a deactivation phase.")
-
-(defvar-local org-transclusion-blocks--suppress-overlays nil
-  "When non-nil, skip overlay creation during transclusion.
-
-Set by transient menus during interactive range adjustment to
-avoid expensive overlay operations and redisplay on every
-incremental change.
-
-Text properties are still applied immediately for metadata
-tracking.  Overlays are created when this variable is nil or when
-`org-transclusion-blocks--ensure-overlays-applied' is called
-after transient exits.
-
-Cleared by `org-transclusion-blocks--ensure-overlays-applied'.")
-
-(defvar-local org-transclusion-blocks--undo-handle nil
-  "Change group handle for transient menu undo consolidation.
-
-Set by `org-transclusion-blocks-lines-menu' when entering the
-transient menu.  Cleared by cleanup function on exit.
-
-Used by `org-transclusion-blocks--apply-metadata' to determine
-whether to suppress text property undo entries.  When non-nil,
-text property changes are not recorded in undo list to prevent
-undo corruption when undoing/redoing content changes.
-
-See Info node `(elisp)Atomic Changes' for change group protocol.")
 
 ;;;; Variable Expansion Support
 ;;
@@ -1338,7 +1272,6 @@ KEYWORD-PLIST is org-transclusion keyword plist.
 Returns content string or nil.
 
 Delegates to `org-transclusion-add-functions' hook.
-Caches payload in `org-transclusion-blocks--last-payload'.
 
 Called by `org-transclusion-blocks-add'."
   (when-let* ((link-string (plist-get keyword-plist :link))
@@ -1348,229 +1281,28 @@ Called by `org-transclusion-blocks-add'."
                             'org-transclusion-add-functions
                             link
                             keyword-plist)))
-        (setq org-transclusion-blocks--last-payload payload)
         (plist-get payload :src-content)))))
 
-;;;; Metadata insertion
-(defun org-transclusion-blocks--find-existing-overlay (beg end)
-  "Find existing transclusion overlay in region BEG to END.
+;;;; Content Insertion
 
-Returns overlay with `org-transclusion-blocks-overlay' property
-or nil if none exists.
-
-Used by `org-transclusion-blocks--apply-metadata' to reuse
-overlays across content updates."
-  (seq-find
-   (lambda (ov)
-     (overlay-get ov 'org-transclusion-blocks-overlay))
-   (overlays-in beg end)))
-
-(defun org-transclusion-blocks--get-or-create-id (beg end)
-  "Return existing transclusion ID for region BEG to END or create new one.
-
-Checks text properties in region for existing `org-transclusion-blocks-id'.
-If found, returns that ID to maintain stability across updates.
-Otherwise generates new UUID.
-
-ID stability is critical for overlay pairing -- changing IDs on
-every update breaks source overlay tracking."
-  (or (get-text-property beg 'org-transclusion-blocks-id)
-      (org-id-uuid)))
-
-(defun org-transclusion-blocks--ensure-overlays-applied ()
-  "Apply overlays if suppression was active.
-
-Called after transient menu exits to create overlays for the
-current transclusion after interactive adjustment completes.
-
-Text properties are already present from
-`org-transclusion-blocks-add' calls during adjustment, so this
-function only creates overlays using existing metadata."
-  (when org-transclusion-blocks--suppress-overlays
-    (setq org-transclusion-blocks--suppress-overlays nil)
-    (save-excursion
-      (let ((element (org-element-at-point)))
-        (when (org-transclusion-blocks--supported-block-p element)
-          (let* ((block-beg (org-element-property :begin element))
-                 (block-end (org-element-property :end element))
-                 (id (get-text-property block-beg 'org-transclusion-blocks-id))
-                 (keyword-plist (get-text-property block-beg 'org-transclusion-blocks-keyword))
-                 (link-string (get-text-property block-beg 'org-transclusion-blocks-link)))
-            (when (and id keyword-plist link-string)
-              (let* ((payload (org-transclusion-blocks--get-payload-for-metadata link-string keyword-plist))
-                     (src-beg (plist-get payload :src-beg))
-                     (src-end (plist-get payload :src-end))
-                     (src-buf (plist-get payload :src-buf)))
-                (when (and src-beg src-end src-buf)
-                  (org-transclusion-blocks--create-overlays
-                   block-beg block-end src-beg src-end src-buf id))))))))))
-
-(defun org-transclusion-blocks--create-overlays (block-beg block-end src-beg src-end src-buf id)
-  "Create transclusion overlays for block and source regions.
-
-BLOCK-BEG and BLOCK-END delimit transclusion block in current buffer.
-SRC-BEG and SRC-END delimit source region in SRC-BUF.
-ID is unique transclusion identifier.
-
-Deletes existing overlays with matching ID before creating new ones
-to avoid accumulation while preserving overlays from other transclusions.
-
-Source overlays do NOT install `modification-hooks' to avoid
-interfering with org-transclusion's own overlay management in the
-source buffer.
-
-Called by `org-transclusion-blocks--apply-metadata' and
-`org-transclusion-blocks--ensure-overlays-applied'."
-  (let ((tc-buffer (current-buffer)))
-    ;; Delete existing overlays for THIS transclusion only
-    (dolist (ov (overlays-in block-beg block-end))
-      (when (and (overlay-get ov 'org-transclusion-blocks-overlay)
-                 (or (not (overlay-get ov 'org-transclusion-blocks-id))
-                     (equal (overlay-get ov 'org-transclusion-blocks-id) id)))
-        (delete-overlay ov)))
-
-    ;; Create fresh overlays
-    (let ((ov-src (make-overlay src-beg src-end src-buf))
-          (ov-tc (make-overlay block-beg block-end)))
-
-      ;; Configure source overlay
-      ;; NOTE: No modification-hooks, no read-only, no fringe indicators.
-      ;; This overlay is purely for tracking the source region.
-      (overlay-put ov-src 'org-transclusion-blocks-by id)
-      (overlay-put ov-src 'org-transclusion-blocks-buffer tc-buffer)
-      (overlay-put ov-src 'evaporate t)
-      (overlay-put ov-src 'org-transclusion-blocks-pair ov-tc)
-      (overlay-put ov-src 'org-transclusion-blocks-id id)
-
-      ;; Configure transclusion overlay
-      (overlay-put ov-tc 'evaporate t)
-      (overlay-put ov-tc 'org-transclusion-blocks-pair ov-src)
-      (overlay-put ov-tc 'org-transclusion-blocks-overlay t)
-      (overlay-put ov-tc 'org-transclusion-blocks-id id)
-
-      ;; Update text property to reference new source overlay
-      (put-text-property block-beg block-end
-                         'org-transclusion-blocks-src-overlay ov-src))))
-
-(defun org-transclusion-blocks--apply-metadata (block-beg block-end keyword-plist link-string)
-  "Apply transclusion metadata properties to block region BLOCK-BEG to BLOCK-END.
-
-BLOCK-BEG is beginning of entire block including delimiters.
-BLOCK-END is end of entire block including delimiters.
-KEYWORD-PLIST is the org-transclusion keyword plist.
-LINK-STRING is the constructed link string (with [[ ]] brackets).
-
-Always applies text properties immediately for metadata tracking.
-Creates overlays only when `org-transclusion-blocks--suppress-overlays'
-is nil.
-
-When `org-transclusion-blocks--undo-handle' is non-nil (during
-transient menu), text property changes are not recorded in undo
-list to prevent undo corruption when undoing/redoing content
-changes.
-
-Properties stored (all namespaced to org-transclusion-blocks):
-- `org-transclusion-blocks-keyword' - Full keyword plist
-- `org-transclusion-blocks-link' - Constructed link string
-- `org-transclusion-blocks-max-line' - Source buffer line count
-- `org-transclusion-blocks-id' - Unique transclusion identifier
-- `org-transclusion-blocks-tc-type' - Transclusion type string
-- `org-transclusion-blocks-src-overlay' - Source overlay
-
-These properties are deliberately distinct from org-transclusion's
-`org-transclusion-id', `org-transclusion-type', and
-`org-transclusion-pair' to prevent org-transclusion's save hooks
-from detecting block transclusions as active transclusions and
-attempting removal.
-
-Called by `org-transclusion-blocks-add'."
-  (let* ((max-line (org-transclusion-blocks--get-source-line-count link-string))
-         (payload (org-transclusion-blocks--get-payload-for-metadata link-string keyword-plist))
-         (src-beg (plist-get payload :src-beg))
-         (src-end (plist-get payload :src-end))
-         (src-buf (plist-get payload :src-buf))
-         (tc-type (plist-get payload :tc-type))
-         (id (or (get-text-property block-beg 'org-transclusion-blocks-id)
-                 (org-id-uuid)))
-         (undo-list-before (when org-transclusion-blocks--undo-handle
-                             buffer-undo-list)))
-
-    ;; Apply text properties
-    (if (and src-beg src-end src-buf)
-        (add-text-properties
-         block-beg block-end
-         `(org-transclusion-blocks-keyword ,keyword-plist
-           org-transclusion-blocks-link ,link-string
-           org-transclusion-blocks-max-line ,max-line
-           org-transclusion-blocks-tc-type ,tc-type
-           org-transclusion-blocks-id ,id))
-      (add-text-properties
-       block-beg block-end
-       `(org-transclusion-blocks-keyword ,keyword-plist
-         org-transclusion-blocks-link ,link-string
-         org-transclusion-blocks-max-line ,max-line)))
-
-    ;; Remove text property undo entries during transient menu
-    (when org-transclusion-blocks--undo-handle
-      (setq buffer-undo-list undo-list-before))
-
-    ;; Create overlays only when not suppressed
-    (unless org-transclusion-blocks--suppress-overlays
-      (when (and src-beg src-end src-buf)
-        (org-transclusion-blocks--create-overlays
-         block-beg block-end src-beg src-end src-buf id)))))
-
-(defun org-transclusion-blocks--get-payload-for-metadata (link-string keyword-plist)
-  "Obtain payload for metadata storage from LINK-STRING and KEYWORD-PLIST.
-
-LINK-STRING is complete link including [[ ]] brackets.
-KEYWORD-PLIST is org-transclusion keyword plist.
-
-Returns payload plist with :src-beg, :src-end, :src-buf, :tc-type.
-
-This is a lightweight call to org-transclusion-add-functions
-solely for metadata extraction, not content fetching.
-
-Called by `org-transclusion-blocks--apply-metadata'."
-  (or org-transclusion-blocks--last-payload
-      (when-let* ((link (org-transclusion-wrap-path-to-link link-string)))
-        (run-hook-with-args-until-success
-         'org-transclusion-add-functions
-         link
-         keyword-plist))))
-
-(defun org-transclusion-blocks--get-source-line-count (link-string)
-  "Return line count of buffer targeted by LINK-STRING.
+(defun org-transclusion-blocks--source-line-count (link-string)
+  "Return line count of source targeted by LINK-STRING.
 
 LINK-STRING is complete link including [[ ]] brackets.
 
-Returns nil if buffer cannot be opened or has no content.
+Returns nil if source cannot be opened.
 
-Used by `org-transclusion-blocks--apply-metadata'."
+Used by `org-transclusion-blocks-lines--at-upper-boundary-p'."
   (condition-case nil
-      (let ((link (org-transclusion-wrap-path-to-link link-string)))
+      (when-let* ((link (org-transclusion-wrap-path-to-link link-string)))
         (save-window-excursion
           (save-excursion
-            ;; Open link in background
             (org-link-open link)
-            ;; Count lines in opened buffer
             (with-current-buffer (current-buffer)
               (count-lines (point-min) (point-max))))))
     (error nil)))
-;;;; Content Insertion
 
-(defun org-transclusion-blocks--apply-timestamp (beg end)
-  "Apply fetch timestamp property to region BEG to END.
 
-BEG is buffer position.
-END is buffer position.
-
-Sets `org-transclusion-blocks-timestamp-property' text property.
-
-Called by `org-transclusion-blocks-add'."
-  (add-text-properties beg end
-                       (list org-transclusion-blocks-timestamp-property
-                             (current-time))))
 
 (defun org-transclusion-blocks--show-indicator (element)
   "Display success indicator overlay on block ELEMENT.
@@ -1614,24 +1346,76 @@ Called by `org-transclusion-blocks-add'."
                                   (when (overlay-buffer overlay)
                                     (delete-overlay overlay)))
                                 ov)))
-        (overlay-put ov 'org-transclusion-blocks-timer timer))))
-
-  ;; (when org-transclusion-blocks--last-fetch-time
-  ;; (message "Content fetched at %s"
-  ;;          (format-time-string "%H:%M:%S"
-  ;;                              org-transclusion-blocks--last-fetch-time)))
-  )
+        (overlay-put ov 'org-transclusion-blocks-timer timer)))))
 
 (defun org-transclusion-blocks-transcluded-p ()
-  "Return non-nil if block at point has transclusion metadata.
+  "Return non-nil if block at point has transclusion headers and content.
 
-Checks `org-transclusion-blocks-keyword' text property on block start.
+Checks for :transclude or :transclude-type headers and non-empty
+block body.
 
-Used by `org-transclusion-blocks-remove' to guard content removal."
+Used by UI commands to determine block state."
+  (let* ((element (org-element-at-point)))
+    (when (org-transclusion-blocks--supported-block-p element)
+      (let* ((bounds (org-transclusion-blocks--get-content-bounds element))
+             (has-content (/= (car bounds) (cdr bounds)))
+             (type (org-element-type element))
+             (params (if (eq type 'src-block)
+                         (nth 2 (org-babel-get-src-block-info 'no-eval))
+                       (org-transclusion-blocks--parse-headers-direct element))))
+        (and has-content
+             (or (assq :transclude params)
+                 (assq :transclude-type params)))))))
+
+;;; Metadata Generation
+
+(defun org-transclusion-blocks--reconstruct-metadata ()
+  "Reconstruct transclusion metadata for block at point from headers.
+
+Parses headers to rebuild keyword plist, link string, and source
+coordinates without storing any persistent state.
+
+Returns plist with :keyword-plist, :link-string, :src-beg,
+:src-end, :src-buf, :tc-type, or nil if block has no transclusion
+headers.
+
+This function re-fetches the payload from `org-transclusion-add-functions'
+to obtain source coordinates.  It is not suitable for tight loops.
+
+Intended for future live-sync integration where org-transclusion
+machinery requires specific text properties or overlays.  Call at
+the point of need rather than storing metadata permanently.
+
+Block transclusions are declarative -- all transclusion parameters
+live in headers and can be reconstructed at any time.  This function
+provides the bridge to org-transclusion's imperative metadata model
+when needed.
+
+See `org-transclusion-blocks-add' for header parsing pipeline."
   (let* ((element (org-element-at-point))
-         (block-beg (org-element-property :begin element)))
-    (and (org-transclusion-blocks--supported-block-p element)
-         (get-text-property block-beg 'org-transclusion-blocks-keyword))))
+         (type (org-element-type element)))
+    (when (org-transclusion-blocks--supported-block-p element)
+      (save-excursion
+        (goto-char (org-element-property :begin element))
+        (let* ((params (if (eq type 'src-block)
+                           (nth 2 (org-babel-get-src-block-info 'no-eval))
+                         (org-transclusion-blocks--parse-headers-direct element)))
+               (expanded-params (org-transclusion-blocks--expand-header-vars params))
+               (keyword-plist (org-transclusion-blocks--params-to-plist expanded-params))
+               (link-string (plist-get keyword-plist :link)))
+          (when keyword-plist
+            (when-let* ((link (org-transclusion-wrap-path-to-link link-string))
+                        (payload (save-window-excursion
+                                   (run-hook-with-args-until-success
+                                    'org-transclusion-add-functions
+                                    link
+                                    keyword-plist))))
+              (list :keyword-plist keyword-plist
+                    :link-string link-string
+                    :src-beg (plist-get payload :src-beg)
+                    :src-end (plist-get payload :src-end)
+                    :src-buf (plist-get payload :src-buf)
+                    :tc-type (plist-get payload :tc-type)))))))))
 
 ;;;; Public Commands
 
@@ -1674,21 +1458,6 @@ Strips trailing blank lines from fetched content unless :lines or
 whitespace in element boundaries.  Line-bounded transclusions
 preserve all whitespace for positional stability.
 
-Stores metadata in text properties for boundary checking:
-- `org-transclusion-blocks-keyword' - keyword plist
-- `org-transclusion-blocks-link' - constructed link
-- `org-transclusion-blocks-max-line' - source line count
-- `org-transclusion-blocks-id' - unique identifier
-- `org-transclusion-blocks-tc-type' - transclusion type
-- `org-transclusion-blocks-src-overlay' - source overlay
-
-All properties use the org-transclusion-blocks namespace to avoid
-interference with org-transclusion's save/remove hooks.
-
-Text properties are always applied immediately.  Overlays are
-created only when `org-transclusion-blocks--suppress-overlays' is
-nil.
-
 See `org-transclusion-blocks-list-types' for available types.
 
 Returns t on success, nil if no headers or fetch failed."
@@ -1727,106 +1496,60 @@ Returns t on success, nil if no headers or fetch failed."
                   (message "No transclusion headers found")
                   nil)
 
-              (let ((link-string (plist-get keyword-plist :link)))
-                (if-let ((content (org-transclusion-blocks--fetch-content keyword-plist)))
-                    (progn
-                      ;; Strip trailing blanks from :post-blank unless
-                      ;; line-bounded transclusion is active
-                      (unless (or (org-transclusion-blocks--get-lines-spec expanded-params)
-                                  (org-transclusion-blocks--get-thing-spec expanded-params))
-                        (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
+              (if-let ((content (org-transclusion-blocks--fetch-content keyword-plist)))
+                  (progn
+                    ;; Strip trailing blanks from :post-blank unless
+                    ;; line-bounded transclusion is active
+                    (unless (or (org-transclusion-blocks--get-lines-spec expanded-params)
+                                (org-transclusion-blocks--get-thing-spec expanded-params))
+                      (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
 
-                      (when (org-transclusion-blocks--should-escape-p keyword-plist expanded-params)
-                        (setq content (org-transclusion-blocks--escape-org-syntax content)))
+                    (when (org-transclusion-blocks--should-escape-p keyword-plist expanded-params)
+                      (setq content (org-transclusion-blocks--escape-org-syntax content)))
 
-                      (let ((block-start (org-element-property :begin element)))
-                        (org-transclusion-blocks--update-content element content)
-                        (setq org-transclusion-blocks--last-fetch-time (current-time))
+                    (let ((block-start (org-element-property :begin element)))
+                      (org-transclusion-blocks--update-content element content)
 
-                        ;; Force re-parse
-                        (goto-char block-start)
-                        (setq element (org-element-at-point))
+                      ;; Re-parse for indicator positioning
+                      (goto-char block-start)
+                      (setq element (org-element-at-point))
 
-                        (let* ((bounds (org-transclusion-blocks--get-content-bounds element))
-                               (content-beg (car bounds))
-                               (content-end (cdr bounds))
-                               (block-beg (org-element-property :begin element))
-                               (block-end (org-element-property :end element)))
+                      (org-transclusion-blocks--show-indicator element)
+                      t))
 
-                          (unless (and block-beg block-end content-beg content-end
-                                       (< block-beg content-beg)
-                                       (< content-beg content-end)
-                                       (< content-end block-end))
-                            (error "Invalid block boundaries after content insertion: block[%s-%s] content[%s-%s]"
-                                   block-beg block-end content-beg content-end))
-
-                          (org-transclusion-blocks--apply-timestamp content-beg content-end)
-                          (org-transclusion-blocks--apply-metadata block-beg block-end keyword-plist link-string))
-
-                        (org-transclusion-blocks--show-indicator element)
-                        t))
-
-                  (message "Failed to fetch transclusion content")
-                  nil)))))))))
+                (message "Failed to fetch transclusion content")
+                nil))))))))
 
 ;;;###autoload
-(defun org-transclusion-blocks-remove (&optional keep-properties)
+(defun org-transclusion-blocks-remove ()
   "Remove transcluded content from block at point.
 
 Delete content between block delimiters while preserving block
 structure (#+HEADER lines, #+begin/#+end delimiters).
 
-When KEEP-PROPERTIES is non-nil (prefix argument), preserve
-transclusion metadata properties on block for re-transclusion
-via `org-transclusion-blocks-add'.  Otherwise, remove all
-transclusion-related text properties and overlays.
-
 Point must be on or within a supported block type.
 
-Return t if content was removed, nil if block had no transclusion
-metadata.
+Return t if content was removed, nil if block is empty.
 
-Uses `org-transclusion-blocks-transcluded-p' to check metadata.
 Uses `org-transclusion-blocks--get-content-bounds' to locate content.
 
 Inverse of `org-transclusion-blocks-add'."
-  (interactive "P")
+  (interactive)
   (let* ((element (org-element-at-point))
          (type (org-element-type element)))
 
     (unless (org-transclusion-blocks--supported-block-p element)
       (user-error "Not on a supported block (point on: %s)" type))
 
-    (if (not (org-transclusion-blocks-transcluded-p))
-        (progn
-          (message "Block has no transclusion metadata")
-          nil)
+    (let* ((bounds (org-transclusion-blocks--get-content-bounds element))
+           (content-beg (car bounds))
+           (content-end (cdr bounds)))
 
-      (let* ((block-beg (org-element-property :begin element))
-             (block-end (org-element-property :end element))
-             (bounds (org-transclusion-blocks--get-content-bounds element))
-             (content-beg (car bounds))
-             (content-end (cdr bounds)))
-
-        ;; Delete content
+      (if (= content-beg content-end)
+          (progn
+            (message "Block is already empty")
+            nil)
         (delete-region content-beg content-end)
-
-        ;; Remove properties and overlays unless preservation requested
-        (unless keep-properties
-          (remove-text-properties
-           block-beg block-end
-           '(org-transclusion-blocks-keyword nil
-             org-transclusion-blocks-link nil
-             org-transclusion-blocks-max-line nil
-             org-transclusion-blocks-fetched nil
-             org-transclusion-blocks-id nil
-             org-transclusion-blocks-tc-type nil
-             org-transclusion-blocks-src-overlay nil))
-
-          (dolist (ov (overlays-in block-beg block-end))
-            (when (overlay-get ov 'org-transclusion-blocks-overlay)
-              (delete-overlay ov))))
-
         (message "Removed transcluded content from %s block" type)
         t))))
 
@@ -1852,18 +1575,6 @@ Useful for testing validator configurations during development."
             (message "Validation passed for %s block" type))
         (error
          (message "Validation failed: %s" (error-message-string err)))))))
-
-(defun org-transclusion-blocks--ensure-yank-exclusions ()
-  "Add transclusion properties to `yank-excluded-properties' if missing.
-
-This function is idempotent and safe to call multiple times.
-It preserves any existing exclusions while adding our properties."
-  (dolist (prop org-transclusion-blocks-yank-excluded-properties)
-    (unless (memq prop yank-excluded-properties)
-      (push prop yank-excluded-properties))))
-
-;; Install exclusions at load time
-(org-transclusion-blocks--ensure-yank-exclusions)
 
 (provide 'org-transclusion-blocks)
 ;;; org-transclusion-blocks.el ends here

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -196,6 +196,14 @@ Declared here to suppress byte-compiler warnings in
 Declared here to suppress byte-compiler warnings in
 `org-transclusion-blocks--source-is-org-p'.")
 
+(defvar org-transclusion-blocks--inhibit-buffer-cleanup nil
+  "When non-nil, skip killing buffers opened during transclusion.
+
+Bound to t by the lines transient menu to avoid repeatedly opening
+and killing source buffers during interactive range adjustment.
+
+Do not set globally.")
+
 ;;;; Variable Expansion Support
 ;;
 ;; Variable expansion is controlled via component metadata in type registry.
@@ -1324,6 +1332,11 @@ Returns content string or nil.
 
 Delegates to `org-transclusion-add-functions' hook.
 
+Kills the source buffer opened during fetch if it was not already
+visiting a file before the call.  Preserves pre-existing buffers.
+Skips cleanup when `org-transclusion-blocks--inhibit-buffer-cleanup'
+is non-nil.
+
 Called by `org-transclusion-blocks-add'."
   (when-let* ((link-string (plist-get keyword-plist :link))
               (link (org-transclusion-wrap-path-to-link link-string)))
@@ -1332,7 +1345,17 @@ Called by `org-transclusion-blocks-add'."
                             'org-transclusion-add-functions
                             link
                             keyword-plist)))
-        (plist-get payload :src-content)))))
+        (let ((content (plist-get payload :src-content))
+              (src-buf (plist-get payload :src-buf)))
+          ;; Kill source buffer if it was opened by the fetch
+          (when (and src-buf
+                     (not org-transclusion-blocks--inhibit-buffer-cleanup)
+                     (buffer-live-p src-buf)
+                     (not (buffer-modified-p src-buf))
+                     (not (plist-get keyword-plist :src-buf-pre-existing)))
+            (let ((kill-buffer-query-functions nil))
+              (kill-buffer src-buf)))
+          content)))))
 
 ;;;; Content Insertion
 

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -1565,6 +1565,17 @@ Called by `org-transclusion-blocks-add'."
   ;;                              org-transclusion-blocks--last-fetch-time)))
   )
 
+(defun org-transclusion-blocks-transcluded-p ()
+  "Return non-nil if block at point has transclusion metadata.
+
+Checks `org-transclusion-blocks-keyword' text property on block start.
+
+Used by `org-transclusion-blocks-remove' to guard content removal."
+  (let* ((element (org-element-at-point))
+         (block-beg (org-element-property :begin element)))
+    (and (org-transclusion-blocks--supported-block-p element)
+         (get-text-property block-beg 'org-transclusion-blocks-keyword))))
+
 ;;;; Public Commands
 
 ;;;###autoload
@@ -1706,57 +1717,64 @@ Returns t on success, nil if no headers or fetch failed."
                   nil)))))))))
 
 ;;;###autoload
-(defun org-transclusion-blocks-add-all (&optional scope)
-  "Fetch and insert content for all blocks in SCOPE.
+(defun org-transclusion-blocks-remove (&optional keep-properties)
+  "Remove transcluded content from block at point.
 
-SCOPE can be:
-  nil or \\='buffer - entire buffer (default)
-  \\='subtree       - current subtree
-  \\='region        - active region
+Delete content between block delimiters while preserving block
+structure (#+HEADER lines, #+begin/#+end delimiters).
 
-Processes all supported block types with transclusion headers.
+When KEEP-PROPERTIES is non-nil (prefix argument), preserve
+transclusion metadata properties on block for re-transclusion
+via `org-transclusion-blocks-add'.  Otherwise, remove all
+transclusion-related text properties and overlays.
 
-Returns list of successfully processed block positions."
-  (interactive)
-  (let ((scope (or scope 'buffer))
-        (success-count 0)
-        (failure-count 0)
-        (processed-positions nil))
+Point must be on or within a supported block type.
 
-    (save-excursion
-      (save-restriction
-        (pcase scope
-          ('buffer (widen))
-          ('subtree (org-narrow-to-subtree))
-          ('region (when (use-region-p)
-                     (narrow-to-region (region-beginning) (region-end)))))
+Return t if content was removed, nil if block had no transclusion
+metadata.
 
-        (org-element-map (org-element-parse-buffer)
-            '(src-block quote-block example-block export-block special-block
-              verse-block center-block comment-block)
-          (lambda (element)
-            (when (or (org-transclusion-blocks--has-typed-components-p element)
-                      (let ((raw-headers (org-element-property :header element)))
-                        (seq-some (lambda (h) (string-match-p ":transclude" h))
-                                  raw-headers)))
-              (goto-char (org-element-property :begin element))
-              (condition-case err
-                  (when (org-transclusion-blocks-add)
-                    (push (point) processed-positions)
-                    (cl-incf success-count))
-                (error
-                 (cl-incf failure-count)
-                 (message "Error at block line %d: %s"
-                          (line-number-at-pos)
-                          (error-message-string err)))))))))
+Uses `org-transclusion-blocks-transcluded-p' to check metadata.
+Uses `org-transclusion-blocks--get-content-bounds' to locate content.
 
-    (message "Processed %d block%s (%d succeeded, %d failed)"
-             (+ success-count failure-count)
-             (if (= (+ success-count failure-count) 1) "" "s")
-             success-count
-             failure-count)
+Inverse of `org-transclusion-blocks-add'."
+  (interactive "P")
+  (let* ((element (org-element-at-point))
+         (type (org-element-type element)))
 
-    (nreverse processed-positions)))
+    (unless (org-transclusion-blocks--supported-block-p element)
+      (user-error "Not on a supported block (point on: %s)" type))
+
+    (unless (org-transclusion-blocks-transcluded-p)
+      (message "Block has no transclusion metadata")
+      (cl-return-from org-transclusion-blocks-remove nil))
+
+    (let* ((block-beg (org-element-property :begin element))
+           (block-end (org-element-property :end element))
+           (bounds (org-transclusion-blocks--get-content-bounds element))
+           (content-beg (car bounds))
+           (content-end (cdr bounds)))
+
+      ;; Delete content
+      (delete-region content-beg content-end)
+
+      ;; Remove properties and overlays unless preservation requested
+      (unless keep-properties
+        (remove-text-properties
+         block-beg block-end
+         '(org-transclusion-blocks-keyword nil
+           org-transclusion-blocks-link nil
+           org-transclusion-blocks-max-line nil
+           org-transclusion-blocks-fetched nil
+           org-transclusion-id nil
+           org-transclusion-type nil
+           org-transclusion-pair nil))
+
+        (dolist (ov (overlays-in block-beg block-end))
+          (when (overlay-get ov 'org-transclusion-blocks-overlay)
+            (delete-overlay ov))))
+
+      (message "Removed transcluded content from %s block" type)
+      t)))
 
 ;;;###autoload
 (defun org-transclusion-blocks-validate-current-block ()
@@ -1780,7 +1798,6 @@ Useful for testing validator configurations during development."
             (message "Validation passed for %s block" type))
         (error
          (message "Validation failed: %s" (error-message-string err)))))))
-
 
 (defun org-transclusion-blocks--ensure-yank-exclusions ()
   "Add transclusion properties to `yank-excluded-properties' if missing.

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -186,15 +186,8 @@ Does not affect non-Org sources (Python files, text files, etc.)."
 
 ;;;; Internal Variables
 
-(defvar org-transclusion-blocks--link-handlers nil
-  "Defined in `org-transclusion-blocks-link-handlers'.
-Declared here to suppress byte-compiler warnings in
-`org-transclusion-blocks--source-is-org-p'.")
-
-(defvar org-transclusion-blocks-generic-link-types nil
-  "Defined in `org-transclusion-blocks-link-handlers'.
-Declared here to suppress byte-compiler warnings in
-`org-transclusion-blocks--source-is-org-p'.")
+(defvar org-transclusion-blocks--link-handlers)
+(defvar org-transclusion-blocks-generic-link-types)
 
 (defvar org-transclusion-blocks--inhibit-buffer-cleanup nil
   "When non-nil, skip killing buffers opened during transclusion.

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -2,7 +2,7 @@
 
 ;; Author: Gino Cornejo
 ;; Maintainer: Gino Cornejo <gggion123@gmail.com>
-;; Homepage: https://github.com/gggion/org-transclusion-blocks
+;; URL: https://github.com/gggion/org-transclusion-blocks
 ;; Keywords: hypermedia vc
 
 ;; Package-Version: 0.4.0

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -110,6 +110,7 @@
 ;; - `org-transclusion-blocks-validate-current-block' - Test validators
 ;; - `org-transclusion-blocks-describe-type' - Show type documentation
 ;; - `org-transclusion-blocks-list-types' - List registered types
+
 ;;; Code:
 
 (require 'org-transclusion)
@@ -118,6 +119,8 @@
 (require 'ol)
 (require 'cl-lib)
 (require 'org-transclusion-blocks-types)
+(require 'org-transclusion-blocks-headers)
+(require 'org-transclusion-blocks-link-handlers)
 
 ;;;; Customization
 

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -162,32 +162,32 @@ Warnings appear in *Warnings* buffer and echo area."
   :group 'org-transclusion-blocks
   :package-version '(org-transclusion-blocks . "0.2.0"))
 
-(defcustom org-transclusion-blocks-escape-org-sources t
-  "Whether to escape Org syntax when transcluding from Org files.
+(defcustom org-transclusion-blocks-no-escape-block-types nil
+  "Block types where Org syntax escaping is skipped.
 
-When non-nil (recommended), automatically escapes content transcluded
-from links targeting Org files (file: links with .org extension,
-id: links, etc.).
+List of block type strings (lowercase, without \"#+begin_\" prefix).
+For example, (\"example\" \"export\") skips escaping for
+example and export blocks.
 
-This prevents Org markup in source content from breaking src block
-structure:
-  - Headlines (*, **, etc.)
-  - Keywords (#+BEGIN, #+PROPERTY, etc.)
-  - Markup characters that start lines
+By default this is nil, meaning all block types have their content
+escaped via `org-escape-code-in-region'.  This prevents transcluded
+content from breaking block structure regardless of source format.
 
-When nil, content is inserted verbatim.  Use :transclude-escape-org
-header to override per-block.
+The :transclude-escape-org header overrides this setting per-block:
+  - Non-nil value forces escaping on
+  - Value of \"nil\", \"no\", \"false\", or \"0\" forces escaping off
 
-Does not affect non-Org sources (Python files, text files, etc.)."
-  :type 'boolean
+Escaping prepends commas to lines starting with *, #+, or , at the
+left margin.  For content without conflicting sequences, escaping
+is a no-op.
+
+Used by `org-transclusion-blocks--should-escape-p'."
+  :type '(repeat string)
   :group 'org-transclusion-blocks
-  :package-version '(org-transclusion-blocks . "0.2.0"))
+  :package-version '(org-transclusion-blocks . "0.5.0"))
 
 
 ;;;; Internal Variables
-
-(defvar org-transclusion-blocks--link-handlers)
-(defvar org-transclusion-blocks-follow-types)
 
 (defvar org-transclusion-blocks--inhibit-buffer-cleanup nil
   "When non-nil, skip killing buffers opened during transclusion.
@@ -536,110 +536,46 @@ Examples:
 
 ;;;; Block Type Support
 
-(defun org-transclusion-blocks--source-is-org-p (link-string)
-  "Return non-nil if LINK-STRING targets Org content.
+(defun org-transclusion-blocks--block-type-string (element)
+  "Return lowercase block type string for ELEMENT.
 
-LINK-STRING is complete link including [[ ]] brackets.
+ELEMENT is org-element block context.
 
-Detect Org sources by:
-- file: links with .org extension
-- id: links (always Org)
-- Custom ID links (always Org)
-- Headline search in any file
-- Links resolvable via explicit handler registry to .org files
-- Links resolvable via `org-transclusion-blocks--invoke-follow'
-  to file buffers with .org extension
+Return string like \"src\", \"quote\", \"example\", or nil if
+ELEMENT is not a block.
 
-When `org-transclusion-blocks--invoke-follow' produces a generated
-buffer (no variable `buffer-file-name'), kill it immediately to prevent
-buffer leaks from the detection check.
+Used by `org-transclusion-blocks--should-escape-p'."
+  (when-let* ((type (org-element-type element)))
+    (let ((name (symbol-name type)))
+      (when (string-suffix-p "-block" name)
+        (substring name 0 (- (length name) 6))))))
 
-Uses `org-transclusion-blocks--link-handlers' for explicit resolvers
-and `org-transclusion-blocks--invoke-follow' for types in
-`org-transclusion-blocks-follow-types'."
-  (when (stringp link-string)
-    (or
-     ;; file:path.org or file:path.org::search
-     (string-match-p (rx "[[file:" (* any) ".org" (or "::" "]]")) link-string)
+(defun org-transclusion-blocks--should-escape-p (element params)
+  "Determine if content should be escaped for ELEMENT.
 
-     ;; id: links (Org files store IDs)
-     (string-match-p (rx "[[id:") link-string)
-
-     ;; Custom ID links
-     (string-match-p (rx "[[#") link-string)
-
-     ;; Headline search in any file
-     (string-match-p (rx "::" (* space) "*") link-string)
-
-     ;; Resolve via explicit registry or follow invocation
-     (when (string-match "\\[\\[\\([^:]+\\):\\([^]]+\\)\\]" link-string)
-       (let* ((type (match-string 1 link-string))
-              (path (match-string 2 link-string))
-              ;; Strip search option from path for resolution
-              (clean-path (if (string-match "\\`\\(.*?\\)::" path)
-                              (match-string 1 path)
-                            path))
-              (file-path
-               (or
-                ;; Explicit resolver
-                (when (bound-and-true-p org-transclusion-blocks--link-handlers)
-                  (when-let* ((resolver
-                               (alist-get type
-                                          org-transclusion-blocks--link-handlers
-                                          nil nil #'string=)))
-                    (condition-case nil
-                        (funcall resolver clean-path)
-                      (error nil))))
-
-                ;; Follow invocation for types in defcustom
-                (when (and (bound-and-true-p
-                            org-transclusion-blocks-follow-types)
-                           (member type
-                                   org-transclusion-blocks-follow-types)
-                           (fboundp
-                            'org-transclusion-blocks--invoke-follow))
-                  (condition-case nil
-                      (when-let* ((buf (org-transclusion-blocks--invoke-follow
-                                        type clean-path)))
-                        (if (buffer-file-name buf)
-                            (buffer-file-name buf)
-                          ;; Generated buffer: not Org, kill to prevent leak
-                          (let ((kill-buffer-query-functions nil))
-                            (kill-buffer buf))
-                          nil))
-                    (error nil))))))
-         (and file-path
-              (stringp file-path)
-              (string-suffix-p ".org" file-path)))))))
-
-(defun org-transclusion-blocks--should-escape-p (keyword-plist params)
-  "Determine if content should be escaped.
-
-KEYWORD-PLIST is org-transclusion keyword plist with :link property.
+ELEMENT is org-element block context.
 PARAMS is alist of header arguments.
 
-Checks in priority order:
-1. Explicit :transclude-escape-org header
-2. Source file type via `org-transclusion-blocks-escape-org-sources'
-3. Default to nil
-
-Returns non-nil if escaping should occur.
+Check in priority order:
+1. Explicit :transclude-escape-org header (overrides everything)
+2. Block type against `org-transclusion-blocks-no-escape-block-types'
+3. Default to t (always escape)
 
 Called by `org-transclusion-blocks-add'."
-  (let ((explicit (assoc-default :transclude-escape-org params))
-        (link-string (plist-get keyword-plist :link)))
+  (let ((explicit (assoc-default :transclude-escape-org params)))
     (cond
      ;; 1. Explicit header overrides everything
      ((and explicit (not (string-empty-p explicit)))
       (not (member explicit '("nil" "no" "false" "0"))))
 
-     ;; 2. Check source type
-     ((and org-transclusion-blocks-escape-org-sources
-           (org-transclusion-blocks--source-is-org-p link-string))
-      t)
+     ;; 2. Check block type exclusion list
+     ((when-let* ((block-type
+                   (org-transclusion-blocks--block-type-string element)))
+        (member block-type org-transclusion-blocks-no-escape-block-types))
+      nil)
 
-     ;; 3. Default: no escaping
-     (t nil))))
+     ;; 3. Default: always escape
+     (t t))))
 
 (defun org-transclusion-blocks--supported-block-p (element)
   "Return non-nil if ELEMENT supports transclusion.
@@ -1596,7 +1532,7 @@ Returns t on success, nil if no headers or fetch failed."
                                 (org-transclusion-blocks--get-thing-spec expanded-params))
                       (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
 
-                    (when (org-transclusion-blocks--should-escape-p keyword-plist expanded-params)
+                    (when (org-transclusion-blocks--should-escape-p element expanded-params)
                       (setq content (org-transclusion-blocks--escape-org-syntax content)))
 
                     (let ((block-start (org-element-property :begin element)))

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -210,7 +210,10 @@ Used by metadata application to avoid re-fetching.")
   '(org-transclusion-blocks-keyword
     org-transclusion-blocks-link
     org-transclusion-blocks-max-line
-    org-transclusion-blocks-fetched)
+    org-transclusion-blocks-fetched
+    org-transclusion-blocks-id
+    org-transclusion-blocks-tc-type
+    org-transclusion-blocks-src-overlay)
   "Text properties excluded from yank operations.
 
 These properties are implementation details for org-transclusion-blocks
@@ -647,6 +650,19 @@ Used by `org-transclusion-blocks--update-content' and
                  (org-element-property :begin element)))
         (forward-line 0)
         (cons beg (point))))))
+
+(defun org-transclusion-blocks--strip-trailing-blanks (content)
+  "Remove trailing blank lines from CONTENT, preserving final newline.
+
+Strips blank lines that org-element includes due to :post-blank
+property on source elements.  Preserves a single trailing newline
+for block delimiter separation.
+
+Returns CONTENT unchanged if it contains no trailing blank lines
+or is not a string."
+  (if (not (stringp content))
+      content
+    (replace-regexp-in-string "\n\\(?:[[:blank:]]*\n\\)+\\'" "\n" content)))
 
 (defun org-transclusion-blocks--ensure-trailing-newline (content)
   "Ensure CONTENT ends with newline without stripping trailing blank lines.
@@ -1315,13 +1331,13 @@ overlays across content updates."
 (defun org-transclusion-blocks--get-or-create-id (beg end)
   "Return existing transclusion ID for region BEG to END or create new one.
 
-Checks text properties in region for existing `org-transclusion-id'.
+Checks text properties in region for existing `org-transclusion-blocks-id'.
 If found, returns that ID to maintain stability across updates.
 Otherwise generates new UUID.
 
-ID stability is critical for org-transclusion.el integration—
-changing IDs on every update breaks source overlay pairing."
-  (or (get-text-property beg 'org-transclusion-id)
+ID stability is critical for overlay pairing -- changing IDs on
+every update breaks source overlay tracking."
+  (or (get-text-property beg 'org-transclusion-blocks-id)
       (org-id-uuid)))
 
 (defun org-transclusion-blocks--ensure-overlays-applied ()
@@ -1340,7 +1356,7 @@ function only creates overlays using existing metadata."
         (when (org-transclusion-blocks--supported-block-p element)
           (let* ((block-beg (org-element-property :begin element))
                  (block-end (org-element-property :end element))
-                 (id (get-text-property block-beg 'org-transclusion-id))
+                 (id (get-text-property block-beg 'org-transclusion-blocks-id))
                  (keyword-plist (get-text-property block-beg 'org-transclusion-blocks-keyword))
                  (link-string (get-text-property block-beg 'org-transclusion-blocks-link)))
             (when (and id keyword-plist link-string)
@@ -1362,15 +1378,18 @@ ID is unique transclusion identifier.
 Deletes existing overlays with matching ID before creating new ones
 to avoid accumulation while preserving overlays from other transclusions.
 
+Source overlays do NOT install `modification-hooks' to avoid
+interfering with org-transclusion's own overlay management in the
+source buffer.
+
 Called by `org-transclusion-blocks--apply-metadata' and
 `org-transclusion-blocks--ensure-overlays-applied'."
   (let ((tc-buffer (current-buffer)))
     ;; Delete existing overlays for THIS transclusion only
     (dolist (ov (overlays-in block-beg block-end))
       (when (and (overlay-get ov 'org-transclusion-blocks-overlay)
-                 ;; Only delete if ID matches or overlay has no ID (old overlay)
-                 (or (not (overlay-get ov 'org-transclusion-id))
-                     (equal (overlay-get ov 'org-transclusion-id) id)))
+                 (or (not (overlay-get ov 'org-transclusion-blocks-id))
+                     (equal (overlay-get ov 'org-transclusion-blocks-id) id)))
         (delete-overlay ov)))
 
     ;; Create fresh overlays
@@ -1378,20 +1397,23 @@ Called by `org-transclusion-blocks--apply-metadata' and
           (ov-tc (make-overlay block-beg block-end)))
 
       ;; Configure source overlay
-      (overlay-put ov-src 'org-transclusion-by id)
-      (overlay-put ov-src 'org-transclusion-buffer tc-buffer)
+      ;; NOTE: No modification-hooks, no read-only, no fringe indicators.
+      ;; This overlay is purely for tracking the source region.
+      (overlay-put ov-src 'org-transclusion-blocks-by id)
+      (overlay-put ov-src 'org-transclusion-blocks-buffer tc-buffer)
       (overlay-put ov-src 'evaporate t)
-      (overlay-put ov-src 'org-transclusion-pair ov-tc)
-      (overlay-put ov-src 'org-transclusion-id id)  ; Add ID to source overlay
+      (overlay-put ov-src 'org-transclusion-blocks-pair ov-tc)
+      (overlay-put ov-src 'org-transclusion-blocks-id id)
 
       ;; Configure transclusion overlay
       (overlay-put ov-tc 'evaporate t)
-      (overlay-put ov-tc 'org-transclusion-pair ov-src)
+      (overlay-put ov-tc 'org-transclusion-blocks-pair ov-src)
       (overlay-put ov-tc 'org-transclusion-blocks-overlay t)
-      (overlay-put ov-tc 'org-transclusion-id id)  ; Add ID to transclusion overlay
+      (overlay-put ov-tc 'org-transclusion-blocks-id id)
 
       ;; Update text property to reference new source overlay
-      (put-text-property block-beg block-end 'org-transclusion-pair ov-src))))
+      (put-text-property block-beg block-end
+                         'org-transclusion-blocks-src-overlay ov-src))))
 
 (defun org-transclusion-blocks--apply-metadata (block-beg block-end keyword-plist link-string)
   "Apply transclusion metadata properties to block region BLOCK-BEG to BLOCK-END.
@@ -1410,18 +1432,19 @@ transient menu), text property changes are not recorded in undo
 list to prevent undo corruption when undoing/redoing content
 changes.
 
-Properties stored:
+Properties stored (all namespaced to org-transclusion-blocks):
 - `org-transclusion-blocks-keyword' - Full keyword plist
 - `org-transclusion-blocks-link' - Constructed link string
 - `org-transclusion-blocks-max-line' - Source buffer line count
-- `org-transclusion-pair' - Source overlay (when overlays created)
-- `org-transclusion-type' - Type for hook dispatch
-- `org-transclusion-id' - Unique transclusion identifier
+- `org-transclusion-blocks-id' - Unique transclusion identifier
+- `org-transclusion-blocks-tc-type' - Transclusion type string
+- `org-transclusion-blocks-src-overlay' - Source overlay
 
-Properties applied to entire block region (including #+HEADER:,
-\"#+begin_src\", and \"#+end_src\" lines) to ensure
-`org-transclusion-at-point' from org-transclusion.el can locate
-transclusion boundaries during `save-buffer' hooks.
+These properties are deliberately distinct from org-transclusion's
+`org-transclusion-id', `org-transclusion-type', and
+`org-transclusion-pair' to prevent org-transclusion's save hooks
+from detecting block transclusions as active transclusions and
+attempting removal.
 
 Called by `org-transclusion-blocks-add'."
   (let* ((max-line (org-transclusion-blocks--get-source-line-count link-string))
@@ -1430,23 +1453,20 @@ Called by `org-transclusion-blocks-add'."
          (src-end (plist-get payload :src-end))
          (src-buf (plist-get payload :src-buf))
          (tc-type (plist-get payload :tc-type))
-         (id (or (get-text-property block-beg 'org-transclusion-id)
+         (id (or (get-text-property block-beg 'org-transclusion-blocks-id)
                  (org-id-uuid)))
-         ;; Save undo list position before text property changes
          (undo-list-before (when org-transclusion-blocks--undo-handle
                              buffer-undo-list)))
 
     ;; Apply text properties
     (if (and src-beg src-end src-buf)
-        ;; Full metadata with source info
         (add-text-properties
          block-beg block-end
          `(org-transclusion-blocks-keyword ,keyword-plist
            org-transclusion-blocks-link ,link-string
            org-transclusion-blocks-max-line ,max-line
-           org-transclusion-type ,tc-type
-           org-transclusion-id ,id))
-      ;; Fallback metadata without source info
+           org-transclusion-blocks-tc-type ,tc-type
+           org-transclusion-blocks-id ,id))
       (add-text-properties
        block-beg block-end
        `(org-transclusion-blocks-keyword ,keyword-plist
@@ -1612,30 +1632,25 @@ Point must be on or within a supported block type.
 For src-blocks, uses Babel for header processing.
 For other blocks, parses headers directly.
 
-Runs pre-validators via `org-transclusion-blocks--pre-validate-headers'
-before variable expansion.  Runs post-validators via
-`org-transclusion-blocks--post-validate-headers' after expansion.
-
-Applies Org syntax escaping via
-`org-transclusion-blocks--escape-org-syntax' when
-`org-transclusion-blocks--should-escape-p' returns non-nil.
+Strips trailing blank lines from fetched content unless :lines or
+:thing-at-point is active, since org-element includes :post-blank
+whitespace in element boundaries.  Line-bounded transclusions
+preserve all whitespace for positional stability.
 
 Stores metadata in text properties for boundary checking:
 - `org-transclusion-blocks-keyword' - keyword plist
 - `org-transclusion-blocks-link' - constructed link
 - `org-transclusion-blocks-max-line' - source line count
-- `org-transclusion-id' - unique identifier
-- `org-transclusion-type' - transclusion type
-- `org-transclusion-pair' - source overlay
+- `org-transclusion-blocks-id' - unique identifier
+- `org-transclusion-blocks-tc-type' - transclusion type
+- `org-transclusion-blocks-src-overlay' - source overlay
 
-Properties applied to entire block region (including headers and
-delimiters) to ensure compatibility with `org-transclusion-at-point'
-from org-transclusion.el during save-buffer hooks.
+All properties use the org-transclusion-blocks namespace to avoid
+interference with org-transclusion's save/remove hooks.
 
 Text properties are always applied immediately.  Overlays are
 created only when `org-transclusion-blocks--suppress-overlays' is
-nil.  This allows transient menus to update content rapidly
-without expensive overlay operations.
+nil.
 
 See `org-transclusion-blocks-list-types' for available types.
 
@@ -1678,16 +1693,20 @@ Returns t on success, nil if no headers or fetch failed."
               (let ((link-string (plist-get keyword-plist :link)))
                 (if-let ((content (org-transclusion-blocks--fetch-content keyword-plist)))
                     (progn
+                      ;; Strip trailing blanks from :post-blank unless
+                      ;; line-bounded transclusion is active
+                      (unless (or (org-transclusion-blocks--get-lines-spec expanded-params)
+                                  (org-transclusion-blocks--get-thing-spec expanded-params))
+                        (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
+
                       (when (org-transclusion-blocks--should-escape-p keyword-plist expanded-params)
                         (setq content (org-transclusion-blocks--escape-org-syntax content)))
 
-                      ;; Remember position before content update
                       (let ((block-start (org-element-property :begin element)))
-                        ;; Update content
                         (org-transclusion-blocks--update-content element content)
                         (setq org-transclusion-blocks--last-fetch-time (current-time))
 
-                        ;; Force re-parse by moving to block start and getting fresh element
+                        ;; Force re-parse
                         (goto-char block-start)
                         (setq element (org-element-at-point))
 
@@ -1697,7 +1716,6 @@ Returns t on success, nil if no headers or fetch failed."
                                (block-beg (org-element-property :begin element))
                                (block-end (org-element-property :end element)))
 
-                          ;; Verify we got valid boundaries
                           (unless (and block-beg block-end content-beg content-end
                                        (< block-beg content-beg)
                                        (< content-beg content-end)
@@ -1705,9 +1723,7 @@ Returns t on success, nil if no headers or fetch failed."
                             (error "Invalid block boundaries after content insertion: block[%s-%s] content[%s-%s]"
                                    block-beg block-end content-beg content-end))
 
-                          ;; Always apply timestamp to content
                           (org-transclusion-blocks--apply-timestamp content-beg content-end)
-                          ;; Always apply metadata (properties immediately, overlays conditionally)
                           (org-transclusion-blocks--apply-metadata block-beg block-end keyword-plist link-string))
 
                         (org-transclusion-blocks--show-indicator element)
@@ -1744,37 +1760,38 @@ Inverse of `org-transclusion-blocks-add'."
     (unless (org-transclusion-blocks--supported-block-p element)
       (user-error "Not on a supported block (point on: %s)" type))
 
-    (unless (org-transclusion-blocks-transcluded-p)
-      (message "Block has no transclusion metadata")
-      (cl-return-from org-transclusion-blocks-remove nil))
+    (if (not (org-transclusion-blocks-transcluded-p))
+        (progn
+          (message "Block has no transclusion metadata")
+          nil)
 
-    (let* ((block-beg (org-element-property :begin element))
-           (block-end (org-element-property :end element))
-           (bounds (org-transclusion-blocks--get-content-bounds element))
-           (content-beg (car bounds))
-           (content-end (cdr bounds)))
+      (let* ((block-beg (org-element-property :begin element))
+             (block-end (org-element-property :end element))
+             (bounds (org-transclusion-blocks--get-content-bounds element))
+             (content-beg (car bounds))
+             (content-end (cdr bounds)))
 
-      ;; Delete content
-      (delete-region content-beg content-end)
+        ;; Delete content
+        (delete-region content-beg content-end)
 
-      ;; Remove properties and overlays unless preservation requested
-      (unless keep-properties
-        (remove-text-properties
-         block-beg block-end
-         '(org-transclusion-blocks-keyword nil
-           org-transclusion-blocks-link nil
-           org-transclusion-blocks-max-line nil
-           org-transclusion-blocks-fetched nil
-           org-transclusion-id nil
-           org-transclusion-type nil
-           org-transclusion-pair nil))
+        ;; Remove properties and overlays unless preservation requested
+        (unless keep-properties
+          (remove-text-properties
+           block-beg block-end
+           '(org-transclusion-blocks-keyword nil
+             org-transclusion-blocks-link nil
+             org-transclusion-blocks-max-line nil
+             org-transclusion-blocks-fetched nil
+             org-transclusion-blocks-id nil
+             org-transclusion-blocks-tc-type nil
+             org-transclusion-blocks-src-overlay nil))
 
-        (dolist (ov (overlays-in block-beg block-end))
-          (when (overlay-get ov 'org-transclusion-blocks-overlay)
-            (delete-overlay ov))))
+          (dolist (ov (overlays-in block-beg block-end))
+            (when (overlay-get ov 'org-transclusion-blocks-overlay)
+              (delete-overlay ov))))
 
-      (message "Removed transcluded content from %s block" type)
-      t)))
+        (message "Removed transcluded content from %s block" type)
+        t))))
 
 ;;;###autoload
 (defun org-transclusion-blocks-validate-current-block ()

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -632,6 +632,9 @@ ELEMENT is org-element block context.
 For src-block, uses `org-src--contents-area'.
 For other blocks, calculates bounds from element properties.
 
+Skips all affiliated keywords (#+NAME:, #+CAPTION:, #+ATTR_*:,
+#+HEADER:, #+RESULTS:) before the #+begin_ line.
+
 Used by `org-transclusion-blocks--update-content' and
 `org-transclusion-blocks--apply-timestamp'."
   (if (eq (org-element-type element) 'src-block)
@@ -639,7 +642,7 @@ Used by `org-transclusion-blocks--update-content' and
         (cons (nth 0 area) (nth 1 area)))
     (save-excursion
       (goto-char (org-element-property :begin element))
-      (while (looking-at "^[ \t]*#\\+HEADER:")
+      (while (looking-at "^[ \t]*#\\+[^ \t\n:]+:")
         (forward-line))
       (unless (looking-at "^[ \t]*#\\+begin_")
         (error "Expected #+begin line at position %d" (point)))

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -347,31 +347,65 @@ Examples:
 (defun org-transclusion-blocks--vector-to-link-string (vec)
   "Convert vector VEC to bracket link string.
 
-VEC is a vector parsed by Babel from [[link]] syntax.
-Babel parses [[link]] as (vector (vector \\='link-symbol)).
+VEC is a vector produced by Babel's Elisp `read' from unquoted
+bracket link syntax in header arguments.
 
-Returns string \"[[link]]\" with proper escaping preserved.
+When `org-babel-parse-header-arguments' encounters an unquoted
+value like [[file:path::*Level 1 Heading]], the Elisp reader
+interprets [[ as nested vector literal and splits contents at
+whitespace.  The result is a 1-element outer vector containing
+an inner vector of symbols and integers:
+
+  [[file:path::*A B]] -> (vector (vector \\='file:path::*A \\='B))
+
+This function unwraps the nesting and concatenates all inner
+elements with spaces to reconstruct the original link text,
+then wraps in [[ ]] brackets.
+
+Bracket links containing Elisp-significant characters like
+unmatched parentheses cause `org-babel-read' errors before this
+function is reached.  Escape such characters with backslash in
+the search string:
+
+  [[file:path::\\(defun my-func]]
+
+Returns string \"[[link]]\" with proper bracket wrapping.
 
 Examples:
   Input: [[file:path]]
   Babel: (vector (vector \\='file:path))
   Output: \"[[file:path]]\"
 
-  Input: [[file:path::\\(defun]]
-  Babel: (vector (vector \\='file:path::\\(defun))
-  Output: \"[[file:path::\\(defun]]\""
-  ;; Unwrap nested vectors to find the innermost element
-  (let ((elem vec))
-    (while (and (vectorp elem) (> (length elem) 0))
-      (setq elem (aref elem 0)))
+  Input: [[file:p::*A B C]]
+  Babel: (vector (vector \\='file:p::*A \\='B \\='C))
+  Output: \"[[file:p::*A B C]]\""
+  ;; Unwrap single-element outer vector to reach content vector
+  (let ((inner vec))
+    (while (and (vectorp inner)
+                (= (length inner) 1)
+                (vectorp (aref inner 0)))
+      (setq inner (aref inner 0)))
 
-    ;; Convert innermost element to string and wrap in brackets
-    (let ((link-content
-           (cond
-            ((symbolp elem) (symbol-name elem))
-            ((stringp elem) elem)
-            (t (format "%s" elem)))))
-      (concat "[[" link-content "]]"))))
+    ;; inner is now the flat vector of link components
+    (let ((parts
+           (if (vectorp inner)
+               (mapconcat
+                (lambda (elem)
+                  (cond
+                   ((symbolp elem) (symbol-name elem))
+                   ((stringp elem) elem)
+                   ((numberp elem) (number-to-string elem))
+                   (t (format "%s" elem))))
+                inner
+                " ")
+             ;; Fallback: single non-vector element
+             (cond
+              ((symbolp inner) (symbol-name inner))
+              ((stringp inner) inner)
+              (t (format "%s" inner))))))
+
+      ;; Wrap in brackets unconditionally since read consumes them
+      (concat "[[" parts "]]"))))
 
 (defun org-transclusion-blocks--expand-header-vars (params)
   "Expand variable references in transclusion-related PARAMS.

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -187,7 +187,7 @@ Does not affect non-Org sources (Python files, text files, etc.)."
 ;;;; Internal Variables
 
 (defvar org-transclusion-blocks--link-handlers)
-(defvar org-transclusion-blocks-generic-link-types)
+(defvar org-transclusion-blocks-follow-types)
 
 (defvar org-transclusion-blocks--inhibit-buffer-cleanup nil
   "When non-nil, skip killing buffers opened during transclusion.
@@ -541,17 +541,22 @@ Examples:
 
 LINK-STRING is complete link including [[ ]] brackets.
 
-Detects:
+Detect Org sources by:
 - file: links with .org extension
 - id: links (always Org)
 - Custom ID links (always Org)
-- Org headline links
+- Headline search in any file
 - Links resolvable via explicit handler registry to .org files
-- Links resolvable via generic follow to .org files
+- Links resolvable via `org-transclusion-blocks--invoke-follow'
+  to file buffers with .org extension
+
+When `org-transclusion-blocks--invoke-follow' produces a generated
+buffer (no variable `buffer-file-name'), kill it immediately to prevent
+buffer leaks from the detection check.
 
 Uses `org-transclusion-blocks--link-handlers' for explicit resolvers
-and `org-transclusion-blocks--resolve-link-via-follow' for types in
-`org-transclusion-blocks-generic-link-types'."
+and `org-transclusion-blocks--invoke-follow' for types in
+`org-transclusion-blocks-follow-types'."
   (when (stringp link-string)
     (or
      ;; file:path.org or file:path.org::search
@@ -566,7 +571,7 @@ and `org-transclusion-blocks--resolve-link-via-follow' for types in
      ;; Headline search in any file
      (string-match-p (rx "::" (* space) "*") link-string)
 
-     ;; Resolve via explicit registry or generic follow
+     ;; Resolve via explicit registry or follow invocation
      (when (string-match "\\[\\[\\([^:]+\\):\\([^]]+\\)\\]" link-string)
        (let* ((type (match-string 1 link-string))
               (path (match-string 2 link-string))
@@ -586,16 +591,22 @@ and `org-transclusion-blocks--resolve-link-via-follow' for types in
                         (funcall resolver clean-path)
                       (error nil))))
 
-                ;; Generic follow for types in defcustom
+                ;; Follow invocation for types in defcustom
                 (when (and (bound-and-true-p
-                            org-transclusion-blocks-generic-link-types)
+                            org-transclusion-blocks-follow-types)
                            (member type
-                                   org-transclusion-blocks-generic-link-types)
+                                   org-transclusion-blocks-follow-types)
                            (fboundp
-                            'org-transclusion-blocks--resolve-link-via-follow))
+                            'org-transclusion-blocks--invoke-follow))
                   (condition-case nil
-                      (org-transclusion-blocks--resolve-link-via-follow
-                       type clean-path)
+                      (when-let* ((buf (org-transclusion-blocks--invoke-follow
+                                        type clean-path)))
+                        (if (buffer-file-name buf)
+                            (buffer-file-name buf)
+                          ;; Generated buffer: not Org, kill to prevent leak
+                          (let ((kill-buffer-query-functions nil))
+                            (kill-buffer buf))
+                          nil))
                     (error nil))))))
          (and file-path
               (stringp file-path)
@@ -1319,36 +1330,50 @@ Called by `org-transclusion-blocks-add'."
 (defun org-transclusion-blocks--fetch-content (keyword-plist)
   "Fetch transcluded content using KEYWORD-PLIST.
 
-KEYWORD-PLIST is org-transclusion keyword plist.
+KEYWORD-PLIST is org-transclusion keyword plist with :link property.
 
 Returns content string or nil.
 
 Delegates to `org-transclusion-add-functions' hook.
 
-Kills the source buffer opened during fetch if it was not already
-visiting a file before the call.  Preserves pre-existing buffers.
-Skips cleanup when `org-transclusion-blocks--inhibit-buffer-cleanup'
+Kills source buffers not present before the hook call.  Skips
+cleanup when `org-transclusion-blocks--inhibit-buffer-cleanup'
 is non-nil.
 
 Called by `org-transclusion-blocks-add'."
+  ;; Uses `copy-sequence' on `buffer-list' snapshot and `memq' with
+  ;; `eq' identity comparison on buffer objects.
+  ;;
+  ;; Handles both file-visiting and generated buffers.  A buffer is
+  ;; killed if all conditions hold:
+  ;; 1. It was not in `buffer-list' before the hook call
+  ;; 2. It is still live
+  ;; 3. It is not modified
+  ;;
+  ;; This covers file-visiting buffers opened by `find-file-noselect'
+  ;; and generated buffers created by :follow functions.  Pre-existing
+  ;; buffers (including reused generated buffers like *Help*) are
+  ;; preserved because `memq' finds them in the snapshot.
   (when-let* ((link-string (plist-get keyword-plist :link))
               (link (org-transclusion-wrap-path-to-link link-string)))
-    (save-window-excursion
-      (when-let* ((payload (run-hook-with-args-until-success
-                            'org-transclusion-add-functions
-                            link
-                            keyword-plist)))
-        (let ((content (plist-get payload :src-content))
-              (src-buf (plist-get payload :src-buf)))
-          ;; Kill source buffer if it was opened by the fetch
-          (when (and src-buf
-                     (not org-transclusion-blocks--inhibit-buffer-cleanup)
-                     (buffer-live-p src-buf)
-                     (not (buffer-modified-p src-buf))
-                     (not (plist-get keyword-plist :src-buf-pre-existing)))
-            (let ((kill-buffer-query-functions nil))
-              (kill-buffer src-buf)))
-          content)))))
+    (let ((pre-existing (unless org-transclusion-blocks--inhibit-buffer-cleanup
+                          (copy-sequence (buffer-list)))))
+      (save-window-excursion
+        (when-let* ((payload (run-hook-with-args-until-success
+                              'org-transclusion-add-functions
+                              link
+                              keyword-plist)))
+          (let ((content (plist-get payload :src-content))
+                (src-buf (plist-get payload :src-buf)))
+            ;; Kill source buffer if opened by the fetch
+            (when (and pre-existing
+                       src-buf
+                       (buffer-live-p src-buf)
+                       (not (memq src-buf pre-existing))
+                       (not (buffer-modified-p src-buf)))
+              (let ((kill-buffer-query-functions nil))
+                (kill-buffer src-buf)))
+            content))))))
 
 ;;;; Content Insertion
 

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -191,6 +191,11 @@ Does not affect non-Org sources (Python files, text files, etc.)."
 Declared here to suppress byte-compiler warnings in
 `org-transclusion-blocks--source-is-org-p'.")
 
+(defvar org-transclusion-blocks-generic-link-types nil
+  "Defined in `org-transclusion-blocks-link-handlers'.
+Declared here to suppress byte-compiler warnings in
+`org-transclusion-blocks--source-is-org-p'.")
+
 ;;;; Variable Expansion Support
 ;;
 ;; Variable expansion is controlled via component metadata in type registry.
@@ -540,11 +545,12 @@ Detects:
 - id: links (always Org)
 - Custom ID links (always Org)
 - Org headline links
-- Links resolvable via registered link handlers to .org files
+- Links resolvable via explicit handler registry to .org files
+- Links resolvable via generic follow to .org files
 
-Used by `org-transclusion-blocks--should-escape-p'.
-Uses `org-transclusion-blocks--link-handlers' to resolve
-non-standard link types to file paths when available."
+Uses `org-transclusion-blocks--link-handlers' for explicit resolvers
+and `org-transclusion-blocks--resolve-link-via-follow' for types in
+`org-transclusion-blocks-generic-link-types'."
   (when (stringp link-string)
     (or
      ;; file:path.org or file:path.org::search
@@ -559,25 +565,40 @@ non-standard link types to file paths when available."
      ;; Headline search in any file
      (string-match-p (rx "::" (* space) "*") link-string)
 
-     ;; Resolve via link handler registry
-     (when (and (bound-and-true-p org-transclusion-blocks--link-handlers)
-                (string-match "\\[\\[\\([^:]+\\):\\([^]]+\\)\\]" link-string))
+     ;; Resolve via explicit registry or generic follow
+     (when (string-match "\\[\\[\\([^:]+\\):\\([^]]+\\)\\]" link-string)
        (let* ((type (match-string 1 link-string))
               (path (match-string 2 link-string))
               ;; Strip search option from path for resolution
               (clean-path (if (string-match "\\`\\(.*?\\)::" path)
                               (match-string 1 path)
                             path))
-              (resolver (alist-get type
-                                   org-transclusion-blocks--link-handlers
-                                   nil nil #'string=)))
-         (when resolver
-           (condition-case nil
-               (let ((file-path (funcall resolver clean-path)))
-                 (and file-path
-                      (stringp file-path)
-                      (string-suffix-p ".org" file-path)))
-             (error nil))))))))
+              (file-path
+               (or
+                ;; Explicit resolver
+                (when (bound-and-true-p org-transclusion-blocks--link-handlers)
+                  (when-let* ((resolver
+                               (alist-get type
+                                          org-transclusion-blocks--link-handlers
+                                          nil nil #'string=)))
+                    (condition-case nil
+                        (funcall resolver clean-path)
+                      (error nil))))
+
+                ;; Generic follow for types in defcustom
+                (when (and (bound-and-true-p
+                            org-transclusion-blocks-generic-link-types)
+                           (member type
+                                   org-transclusion-blocks-generic-link-types)
+                           (fboundp
+                            'org-transclusion-blocks--resolve-link-via-follow))
+                  (condition-case nil
+                      (org-transclusion-blocks--resolve-link-via-follow
+                       type clean-path)
+                    (error nil))))))
+         (and file-path
+              (stringp file-path)
+              (string-suffix-p ".org" file-path)))))))
 
 (defun org-transclusion-blocks--should-escape-p (keyword-plist params)
   "Determine if content should be escaped.

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -184,6 +184,13 @@ Does not affect non-Org sources (Python files, text files, etc.)."
   :package-version '(org-transclusion-blocks . "0.2.0"))
 
 
+;;;; Internal Variables
+
+(defvar org-transclusion-blocks--link-handlers nil
+  "Defined in `org-transclusion-blocks-link-handlers'.
+Declared here to suppress byte-compiler warnings in
+`org-transclusion-blocks--source-is-org-p'.")
+
 ;;;; Variable Expansion Support
 ;;
 ;; Variable expansion is controlled via component metadata in type registry.
@@ -533,21 +540,44 @@ Detects:
 - id: links (always Org)
 - Custom ID links (always Org)
 - Org headline links
+- Links resolvable via registered link handlers to .org files
 
-Used by `org-transclusion-blocks--should-escape-p'."
+Used by `org-transclusion-blocks--should-escape-p'.
+Uses `org-transclusion-blocks--link-handlers' to resolve
+non-standard link types to file paths when available."
   (when (stringp link-string)
     (or
      ;; file:path.org or file:path.org::search
      (string-match-p (rx "[[file:" (* any) ".org" (or "::" "]]")) link-string)
 
-     ;; id: links
+     ;; id: links (Org files store IDs)
      (string-match-p (rx "[[id:") link-string)
 
      ;; Custom ID links
      (string-match-p (rx "[[#") link-string)
 
-     ;; Headline search in any file (heuristic)
-     (string-match-p (rx "::" (* space) "*") link-string))))
+     ;; Headline search in any file
+     (string-match-p (rx "::" (* space) "*") link-string)
+
+     ;; Resolve via link handler registry
+     (when (and (bound-and-true-p org-transclusion-blocks--link-handlers)
+                (string-match "\\[\\[\\([^:]+\\):\\([^]]+\\)\\]" link-string))
+       (let* ((type (match-string 1 link-string))
+              (path (match-string 2 link-string))
+              ;; Strip search option from path for resolution
+              (clean-path (if (string-match "\\`\\(.*?\\)::" path)
+                              (match-string 1 path)
+                            path))
+              (resolver (alist-get type
+                                   org-transclusion-blocks--link-handlers
+                                   nil nil #'string=)))
+         (when resolver
+           (condition-case nil
+               (let ((file-path (funcall resolver clean-path)))
+                 (and file-path
+                      (stringp file-path)
+                      (string-suffix-p ".org" file-path)))
+             (error nil))))))))
 
 (defun org-transclusion-blocks--should-escape-p (keyword-plist params)
   "Determine if content should be escaped.

--- a/org-transclusion-blocks.el
+++ b/org-transclusion-blocks.el
@@ -1266,6 +1266,50 @@ Called by `org-transclusion-blocks-add'."
 
 ;;;; Content Fetching
 
+(defun org-transclusion-blocks--fetch-content-via-handler (type params keyword-plist)
+  "Attempt to fetch content via TYPE's registered content handler.
+
+TYPE is link type symbol from :transclude-type header.
+PARAMS is expanded header argument alist.
+KEYWORD-PLIST is plist from `org-transclusion-blocks--params-to-plist'.
+
+Extract components via `org-transclusion-blocks--extract-type-components',
+then call the registered content handler with (COMPONENTS KEYWORD-PLIST).
+
+Return content string if handler succeeds, nil otherwise.
+
+Buffer cleanup follows the same snapshot strategy as
+`org-transclusion-blocks--fetch-content': buffers opened by the
+handler that were not present before the call are killed unless
+modified or `org-transclusion-blocks--inhibit-buffer-cleanup' is
+non-nil.
+
+Called by `org-transclusion-blocks-add' before falling back to
+`org-transclusion-blocks--fetch-content'."
+  (when-let* ((handler (alist-get type org-transclusion-blocks--type-content-handlers))
+              (components (org-transclusion-blocks--extract-type-components type params)))
+    (let ((pre-existing (unless org-transclusion-blocks--inhibit-buffer-cleanup
+                          (copy-sequence (buffer-list)))))
+      (save-window-excursion
+        (condition-case err
+            (when-let* ((payload (funcall handler components keyword-plist)))
+              (let ((content (plist-get payload :src-content))
+                    (src-buf (plist-get payload :src-buf)))
+                ;; Buffer cleanup: same strategy as fetch-content
+                (when (and pre-existing
+                           src-buf
+                           (buffer-live-p src-buf)
+                           (not (memq src-buf pre-existing))
+                           (not (buffer-modified-p src-buf)))
+                  (let ((kill-buffer-query-functions nil))
+                    (kill-buffer src-buf)))
+                content))
+          (error
+           (message "org-transclusion-blocks: content handler for %s failed: %s"
+                    type (error-message-string err))
+           nil))))))
+
+
 (defun org-transclusion-blocks--fetch-content (keyword-plist)
   "Fetch transcluded content using KEYWORD-PLIST.
 
@@ -1479,6 +1523,12 @@ Validation occurs in two phases:
 1. Pre-validation (before expansion): :validator-pre checks syntax
 2. Post-validation (after expansion): :validator-post checks semantics
 
+When a type registers a content handler via
+`org-transclusion-blocks-register-type', content is fetched directly
+via the handler instead of dispatching through
+`org-transclusion-add-functions'.  The handler receives extracted
+components and keyword plist, returning a payload plist.
+
 Point must be on or within a supported block type.
 
 For src-blocks, uses Babel for header processing.
@@ -1527,29 +1577,42 @@ Returns t on success, nil if no headers or fetch failed."
                   (message "No transclusion headers found")
                   nil)
 
-              (if-let ((content (org-transclusion-blocks--fetch-content keyword-plist)))
-                  (progn
-                    ;; Strip trailing blanks from :post-blank unless
-                    ;; line-bounded transclusion is active
-                    (unless (or (org-transclusion-blocks--get-lines-spec expanded-params)
-                                (org-transclusion-blocks--get-thing-spec expanded-params))
-                      (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
+              ;; Try content handler first for typed transclusions,
+              ;; fall back to standard hook dispatch
+              (let* ((tc-type-raw (cdr (assq :transclude-type expanded-params)))
+                     (tc-type (when tc-type-raw
+                                (if (symbolp tc-type-raw) tc-type-raw
+                                  (intern (org-strip-quotes
+                                           (if (stringp tc-type-raw) tc-type-raw
+                                             (format "%s" tc-type-raw)))))))
+                     (content (or (when tc-type
+                                    (org-transclusion-blocks--fetch-content-via-handler
+                                     tc-type expanded-params keyword-plist))
+                                  (org-transclusion-blocks--fetch-content keyword-plist))))
 
-                    (when (org-transclusion-blocks--should-escape-p element expanded-params)
-                      (setq content (org-transclusion-blocks--escape-org-syntax content)))
+                (if content
+                    (progn
+                      ;; Strip trailing blanks from :post-blank unless
+                      ;; line-bounded transclusion is active
+                      (unless (or (org-transclusion-blocks--get-lines-spec expanded-params)
+                                  (org-transclusion-blocks--get-thing-spec expanded-params))
+                        (setq content (org-transclusion-blocks--strip-trailing-blanks content)))
 
-                    (let ((block-start (org-element-property :begin element)))
-                      (org-transclusion-blocks--update-content element content)
+                      (when (org-transclusion-blocks--should-escape-p element expanded-params)
+                        (setq content (org-transclusion-blocks--escape-org-syntax content)))
 
-                      ;; Re-parse for indicator positioning
-                      (goto-char block-start)
-                      (setq element (org-element-at-point))
+                      (let ((block-start (org-element-property :begin element)))
+                        (org-transclusion-blocks--update-content element content)
 
-                      (org-transclusion-blocks--show-indicator element)
-                      t))
+                        ;; Re-parse for indicator positioning
+                        (goto-char block-start)
+                        (setq element (org-element-at-point))
 
-                (message "Failed to fetch transclusion content")
-                nil))))))))
+                        (org-transclusion-blocks--show-indicator element)
+                        t))
+
+                  (message "Failed to fetch transclusion content")
+                  nil)))))))))
 
 ;;;###autoload
 (defun org-transclusion-blocks-remove ()

--- a/testing/examples/transclusion-babel-tests.org
+++ b/testing/examples/transclusion-babel-tests.org
@@ -51,7 +51,7 @@ Expected behavior:
 #+HEADER: :var filepath="org-transclusion-blocks.el"
 #+HEADER: :transclude-type orgit-file
 #+HEADER: :orgit-repo $repo
-#+HEADER: :orgit-rev $master
+#+HEADER: :orgit-rev $branch
 #+HEADER: :orgit-file $filepath
 #+HEADER: :transclude-lines 90-100
 #+begin_src elisp


### PR DESCRIPTION
Still hammering away at this, so far:


## Breaking Changes

-   Removed all transclusion metadata (text properties, source overlays, ID tracking). Block transclusions are now purely declarative. All state lives in headers and is reconstructed on demand. This eliminates buffer corruption caused by property name collisions with org-transclusion.el&rsquo;s save hooks (#6, #11).
-   Removed `org-transclusion-blocks-escape-org-sources` defcustom. Replaced by `org-transclusion-blocks-no-escape-block-types` with inverted semantics: escaping is now unconditional by default for all block types.
-   Removed `org-transclusion-blocks-add-all`. The batch operation only processed one block. Will return when reliable.


## New Features

-   Content handler tier for type registration. `org-transclusion-blocks-register-type` accepts an optional fourth argument CONTENT-HANDLER that receives extracted components and keyword plist directly, bypassing `org-transclusion-add-functions` hook dispatch. Enables custom link types with multi-segment paths, non-file sources, or custom buffer creation (e.g., orgit-file via `magit-find-file-noselect`, org-table extraction, API endpoints).
-   Link handler registry (`org-transclusion-blocks-link-handlers.el`). Three-tier resolution system for non-file link types:
    -   Tier 1: `org-transclusion-blocks-follow-types` for zero-config follow-based resolution (default: `"info"`)
    -   Tier 2: `org-transclusion-blocks-register-link-handler` for explicit path resolvers
    -   Tier 3: Content handlers via `org-transclusion-blocks-register-type` for full control
-   Generated buffer transclusions. Link types whose `:follow` produces a non-file buffer (info:, help:, etc.) are now captured directly with `:lines` range extraction relative to an optional `::search` origin.
-   `:thing-at-point` extraction for generated buffers. Uses `intern` instead of `make-symbol` to ensure symbol property lookup works for standard things.
-   `org-transclusion-blocks-remove` command. Deletes content between block delimiters while preserving headers and block structure. Inverse of `org-transclusion-blocks-add`.
-   `org-transclusion-blocks-transcluded-p` predicate. Checks for transclusion headers and non-empty block body without text properties.
-   `org-transclusion-blocks--reconstruct-metadata` for future live-sync integration. Rebuilds keyword plist, link string, and source coordinates from headers on demand.


## Bug Fixes

-   Fix buffer corruption from property name collisions with org-transclusion.el (#6). Intermediate fix namespaced all properties; final fix eliminated them entirely.
-   Fix bracket links with spaces truncated by Babel (#8). `[[file:path::*Level 1 Heading]]` no longer truncates to `*Level`. All vector elements are concatenated with spaces.
-   Fix content bounds detection for named non-src blocks (#9). `#+NAME:`, `#+CAPTION:`, and `#+ATTR_*:` affiliated keywords are now skipped when locating the `#+begin_` line.
-   Fix trailing blank lines from `:post-blank` in fetched content. Stripped unless `:lines` or `:thing-at-point` is active.
-   Fix `:follow` argument mismatch across link types. Handler retries with one argument on `wrong-number-of-arguments`.
-   Fix `:lines` failure with non-file link types. Handlers intercept at negative depth before `org-transclusion-add-src-lines` attempts `find-file-noselect` on non-file paths.
-   Restore undo consolidation for lines transient menu. Change group protocol was incorrectly removed along with metadata variables.


# Denote/Roam/Custom Link Types (#10)

-   Non-file link types can now be transcluded by adding their type string to `org-transclusion-blocks-follow-types` or registering an explicit resolver via `org-transclusion-blocks-register-link-handler`. No per-type handler code required for types with a `:follow` function.
